### PR TITLE
Add some benchmark Implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,6 +216,6 @@ result*
 
 
 AGENTS.md
-bench_info.md
+# bench_info.md
 ref_repos/*
 scripts/bench_suite

--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,9 @@ SenseNova*
 
 temp
 result*
+
+
+AGENTS.md
+bench_info.md
+ref_repos/*
+scripts/bench_suite

--- a/bench_info.md
+++ b/bench_info.md
@@ -1,0 +1,63 @@
+### Benchmark Table
+
+| No. | Benchmark            | Category   | Importance | 当前实现进度 | 原始仓库支持情况 | 官方VLMEvalKit实现 | 仓库对应名称/说明 | 官方实现/代码 |
+|-----|----------------------|------------|------------|--------------|------------------|--------------------|-------------------|---------------|
+| 1   | MathCanvas-in (3k)   | Math       | 0          | ✓ | 暂不支持（仅 `MathCanvas-Bench`） | 暂不支持（仅 `MathCanvas-Bench`） | 当前仓库新增兼容名称 `MathCanvas-in`、`MathCanvas-in (3k)`，实际映射到官方公开的 `MathCanvas-Bench` 3K benchmark | [MathCanvas](https://github.com/shiwk24/MathCanvas) |
+| 2   | MathVision           | Math       | 0          | ✓ | 支持 | 支持 | `MathVision`、`MathVision_MINI` | [MATH-V / MathVision](https://github.com/mathllm/MATH-V) |
+| 3   | MathVista            | Math       | 0          | ✓ | 暂不支持（仅 `MathVista_MINI`） | 暂不支持（仅 `MathVista_MINI`） | 当前仓库新增完整 `MathVista` 本地官方数据接入，同时保留 `MathVista_MINI` | [MathVista](https://github.com/lupantech/MathVista) |
+| 4   | VSP / VSP-in         | Spatial    | 0          |  | 暂不支持（仅 `VSP_maze_task_main_original`） | 暂不支持 | 当前仓库新增 `VSP`、`VSP-in` 命名兼容，但底层仍对应官方已公开的 `VSP_maze_task_main_original` maze split；官方仓库暂未公开完整 benchmark 数据 | [VisualPlanning](https://github.com/yix8/VisualPlanning) |
+| 5   | MindCube             | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库新增 `MindCube`、`MindCubeBench`、`MindCubeBench_raw_qa`、`MindCubeBench_tiny_raw_qa` | [MindCube](https://github.com/mll-lab-nu/MindCube) |
+| 6   | MMSI                 | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库新增 `MMSI`、`MMSIBench`、`MMSIBench_wo_circular`；`MMSI` 默认映射官方 non-circular 评测集 | [MMSI-Bench](https://github.com/OpenRobotLab/MMSI-Bench) |
+| 7   | EMMA                 | General    | 0          | ✓ | 支持 | 支持 | `EMMA`、`EMMA_COT` | [EMMA](https://github.com/EMMA-Bench/EMMA) |
+| 8   | V*StarBench          | Perception | 0          | ✓ | 支持 | 支持 | `VStarBench` | [V* / VStarBench](https://github.com/penghao-wu/vstar) |
+| 9   | HRBench              | Perception | 0          | ✓ | 支持 | 支持 | `HRBench4K`、`HRBench8K` | [HR-Bench](https://github.com/DreamMr/HR-Bench) |
+| 10  | CVBench              | Perception | 0          | ✓ | 支持 | 支持 | `CV-Bench-2D`、`CV-Bench-3D` | [Cambrian / CV-Bench](https://github.com/cambrian-mllm/cambrian) |
+| 11  | MMVP                 | Perception | 0          | ✓ | 支持 | 支持 | `MMVP` | [MMVP](https://github.com/tsb0601/MMVP) |
+| 12  | BLINK                | Perception | 0          | ✓ | 支持 | 支持 | `BLINK`、`BLINK_circular`，另含 `BLINK_Jigsaw` | [BLINK](https://github.com/zeyofu/BLINK_Benchmark) |
+| 13  | MMMU                 | General    | 0          | ✓ | 支持 | 支持 | `MMMU_DEV_VAL`、`MMMU_TEST`，另含 `MMMU_Pro_*` | [MMMU](https://github.com/MMMU-Benchmark/MMMU) |
+| 14  | ScienceQA            | General    | 0          | ✓ | 支持 | 支持 | `ScienceQA_VAL`、`ScienceQA_TEST` | [ScienceQA](https://github.com/lupantech/ScienceQA) |
+| 15  | ARC-AGI              | General    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增 `ARC-AGI`：基于官方 `ARC-AGI-2` public evaluation JSON 渲染任务图，要求模型输出 JSON grid，并做 exact-match task-level eval | [ARC-AGI-2](https://github.com/arcprize/ARC-AGI-2) |
+
+### 本地已跑结果汇总
+
+当前已检查的结果目录：`results/Qwen2.5-VL-7B-Instruct/T20260321_Gbfc358a1`
+
+| Benchmark | 本地结果 | 结果文件 | 备注 |
+|-----------|----------|----------|------|
+| MathCanvas-in (3k) | 已生成预测文件，暂未见自动汇总分数 | `Qwen2.5-VL-7B-Instruct_MathCanvas-in.xlsx` | 表头仅含 `question/answer/prediction`，当前没有配套 `acc.csv/json` |
+| MathVision | 已生成预测文件，暂未见自动汇总分数 | `Qwen2.5-VL-7B-Instruct_MathVision.xlsx` | 当前没有配套 `acc.csv/json` |
+| VSP | 已生成预测文件，暂未见自动汇总分数 | `Qwen2.5-VL-7B-Instruct_VSP.xlsx` | 当前没有配套 `acc.csv/json` |
+| VSP-in | 已生成预测文件，暂未见自动汇总分数 | `Qwen2.5-VL-7B-Instruct_VSP-in.xlsx` | 当前没有配套 `acc.csv/json` |
+| EMMA | 已生成预测文件，暂未见自动汇总分数 | `Qwen2.5-VL-7B-Instruct_EMMA.xlsx` | 当前没有配套 `acc.csv/json` |
+| V*StarBench | `Overall = 76.44%` | `Qwen2.5-VL-7B-Instruct_VStarBench_acc.csv` | 子项：`direct_attributes = 77.39%`，`relative_position = 75.00%` |
+| CVBench | `2D = 74.90%`，`3D = 73.58%` | `Qwen2.5-VL-7B-Instruct_CV-Bench-2D_acc.csv`，`Qwen2.5-VL-7B-Instruct_CV-Bench-3D_acc.csv` | 2D 子项：`COCO = 81.86%`，`ADE20K = 67.93%`；3D 子项：`Depth = 70.33%`，`Distance = 76.83%` |
+| MMVP | `Overall = 77.33%` | `Qwen2.5-VL-7B-Instruct_MMVP_acc.csv` | 已有自动汇总 |
+| ScienceQA | `VAL = 71.58%`，`TEST = 72.78%` | `Qwen2.5-VL-7B-Instruct_ScienceQA_VAL_acc.csv`，`Qwen2.5-VL-7B-Instruct_ScienceQA_TEST_acc.csv` | 已有自动汇总 |
+| ARC-AGI | `overall_task_accuracy = 0.00%`（`0 / 120` tasks） | `Qwen2.5-VL-7B-Instruct_ARC-AGI_score.json` | 任务级 exact-match 评测 |
+
+### Qwen2.5-VL-7B 公开结果对比
+
+| Benchmark | 本地结果 | 公开/官方结果 | 差值 | 来源 | 备注 |
+|-----------|----------|---------------|------|------|------|
+| V*StarBench | `76.44%` | `76.44%` | `0.00` | [ThinkMorph README](https://github.com/ThinkMorph/ThinkMorph) | 公开表中的 `VStar` 与当前本地 `VStarBench` 数值完全一致 |
+| MMVP | `77.33%` | `77.33%` | `0.00` | [ThinkMorph README](https://github.com/ThinkMorph/ThinkMorph) | 数值完全一致 |
+| CVBench | `2D = 74.90%`，`3D = 73.58%` | `CV-Bench = 75.20%` | `约 -0.96` | [ThinkMorph README](https://github.com/ThinkMorph/ThinkMorph) | 公开表给的是单一 `CV-Bench` 总分；本地当前输出是 `2D/3D` split。这里的差值按 `(74.90 + 73.58) / 2 = 74.24` 做简单近似，仅供参考 |
+| ScienceQA | `TEST = 72.78%`，`VAL = 71.58%` | `IMG Score = 88.6` | `不直接可比` | [Wizwand ScienceQA 榜单](https://www.wizwand.com/task/science-question-answering) | 该公开页面给的是第三方聚合的 `ScienceQA / IMG Score`，不是当前 VLMEvalKit 结果文件里的 `Overall` 指标，口径不一致 |
+| ARC-AGI | `0.00%` | `未找到可靠公开结果` | `-` | - | 检索公开网页时，暂未找到可复核的 `Qwen2.5-VL-7B` ARC-AGI 分数 |
+
+### 结果解读
+
+- 当前已经自动产出汇总分数的 benchmark 里，`MMVP (77.33%)` 和 `V*StarBench (76.44%)` 是表现最好的两项。
+- `CVBench` 当前拆成 `2D = 74.90%` 与 `3D = 73.58%` 两个 split；如果只做粗略平均，大约是 `74.24%`，与公开 ThinkMorph 表里的 `75.20` 基本接近。
+- `ScienceQA` 当前 `TEST = 72.78%`、`VAL = 71.58%`，说明模型在常规图文科学问答上是能稳定工作的，但相比官方/公开聚合榜单里的高分结果，仍有明显差距。
+- `MathCanvas-in`、`MathVision`、`VSP`、`VSP-in`、`EMMA` 目前已经生成预测文件，但当前结果目录下还没有自动评测后生成的 `acc.csv/json`，所以暂时只能算“已跑完预测，未完成汇总打分”。
+- 对于“官网结果”这件事，要区分来源：`Qwen` 官方模型卡公开了 `MMMU / MathVista / MathVision` 等通用 benchmark 分数，但没有公开 `V*StarBench / MMVP / CV-Bench / ScienceQA / ARC-AGI` 的完整同口径结果；因此上表里这些重合项主要参考的是 `ThinkMorph` 公开结果表，而不是 `Qwen` 官方模型卡。
+
+### ARC-AGI 说明
+
+- `ARC-AGI` 测的是抽象规则归纳与组合泛化。每个任务会给出若干组 `train input -> train output` 网格示例，以及一个或多个 `test input`；模型需要自己归纳变换规则，并输出对应的 `test output` 网格。
+- 当前仓库里的实现见 `vlmeval/dataset/arc_agi.py`。它会把每个任务渲染成一张图，把训练对和测试输入都画出来，然后要求模型“只返回 JSON”，输出格式必须是 `[[...]]` 或 `{\"test_1\": [[...]], ...}` 这种 grid 结构。
+- 评分口径非常严格：不是多选题 accuracy，也不是 token-level 相似度，而是 `task-level exact match`。也就是一个任务里所有测试网格都要和标准答案完全一致，才记 `1` 分，否则就是 `0` 分。
+- 本次结果里 `overall_task_accuracy = 0.00%`，对应 `0 / 120` 个 public evaluation tasks 全部 miss。这不是评测脚本挂了，因为结果文件里 `120` 个任务都有预测，且其中 `111` 个任务的输出还能被成功解析成合法 grid/json；只是解析后的结果没有任何一个任务与标准答案完全一致。
+- 因此，这个 `0 分` 更像是“当前 prompt + 直接单次生成 JSON grid”的解题方式对 ARC-AGI 基本无效，而不是简单的格式错误。格式问题确实存在一部分，但不是主因。
+- 这个结果是偏低的，但在 ARC-AGI 这种 benchmark 上并不反常。它本来就是故意设计来测系统性泛化和组合规则发现的；对没有专门 search / program synthesis / self-refine 流程的通用 7B VLM，直接 `0 / 120` 是完全可能出现的。

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 accelerate
-datasets
+# datasets
 dotenv
 einops
 # for gemini api
@@ -32,7 +32,7 @@ setuptools
 sty
 sympy
 tabulate
-tiktoken
+# tiktoken
 timeout-decorator
 timm
 # torch

--- a/run.py
+++ b/run.py
@@ -2,8 +2,6 @@ import json
 import os
 import subprocess
 from functools import partial
-
-
 # GET the number of GPUs on the node without importing libs like torch
 def get_gpu_list():
     CUDA_VISIBLE_DEVICES = os.environ.get('CUDA_VISIBLE_DEVICES', '')

--- a/run_thinkmorph.sh
+++ b/run_thinkmorph.sh
@@ -9,4 +9,3 @@ export OPENAI_API_KEY=
  --model thinkmorph \
  --judge gpt-5 \
  --work-dir ./VLMEvalKit_Thinkmorph/results
-

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -93,6 +93,9 @@ from .medqbench_paired_description import MedqbenchPairedDescriptionDataset
 from .olmOCRBench.olmocrbench import olmOCRBench
 from .oceanocr import OceanOCRBench
 from .matbench import MATBench
+from .mindcubebench import MindCubeBench
+from .mmsibench import MMSIBench
+from .arc_agi import ARCAGIDataset
 
 from .reasonmap_plus import ReasonMap_Plus
 from .hipho import HiPhODataset
@@ -230,7 +233,7 @@ IMAGE_DATASET = [
     AyaVisionBench, TopViewRS, VLMBias, MMHELIX, MedqbenchMCQDataset, MathCanvas, MMReason,
     MedqbenchPairedDescriptionDataset, MedqbenchCaptionDataset, ChartMuseum, ChartQAPro, ReasonMap_Plus,
     olmOCRBench, OceanOCRBench, MATBench, VLRMBench, RefCOCODataset, SimpleVQA, HiPhODataset, MaCBench,
-    UniSVG, SArena_MINI, Refocus, VSPOriginalDataset
+    UniSVG, SArena_MINI, Refocus, VSPOriginalDataset, MindCubeBench, MMSIBench, ARCAGIDataset
 ]
 
 VIDEO_DATASET = [

--- a/vlmeval/dataset/arc_agi.py
+++ b/vlmeval/dataset/arc_agi.py
@@ -1,0 +1,248 @@
+import ast
+import json
+import os
+from pathlib import Path
+
+import pandas as pd
+from PIL import Image, ImageDraw, ImageFont
+
+from .image_base import ImageBaseDataset
+from ..smp.file import LMUDataRoot, dump, get_intermediate_file_path, load
+
+
+ARC_COLORS = {
+    0: (0, 0, 0),
+    1: (0, 116, 217),
+    2: (255, 65, 54),
+    3: (46, 204, 64),
+    4: (255, 220, 0),
+    5: (170, 170, 170),
+    6: (240, 18, 190),
+    7: (255, 133, 27),
+    8: (127, 219, 255),
+    9: (135, 12, 37),
+}
+
+
+def _normalize_grid(value):
+    if isinstance(value, list):
+        grid = value
+    elif isinstance(value, str):
+        text = value.strip()
+        if text.startswith('```'):
+            parts = text.split('```')
+            text = ''
+            for part in reversed(parts):
+                part = part.strip()
+                if part and part.lower() != 'json':
+                    text = part
+                    break
+        candidate_texts = [text]
+        if '{' in text and '}' in text:
+            candidate_texts.append(text[text.find('{'):text.rfind('}') + 1])
+        if '[' in text and ']' in text:
+            candidate_texts.append(text[text.find('['):text.rfind(']') + 1])
+
+        grid = None
+        for candidate in candidate_texts:
+            try:
+                parsed = ast.literal_eval(candidate)
+            except Exception:
+                try:
+                    parsed = json.loads(candidate)
+                except Exception:
+                    continue
+            if isinstance(parsed, list):
+                grid = parsed
+                break
+            if isinstance(parsed, dict):
+                grid = parsed
+                break
+    else:
+        grid = None
+
+    if isinstance(grid, dict):
+        normalized = {}
+        for key, value in grid.items():
+            normalized[key] = _normalize_grid(value)
+        return normalized
+
+    if not isinstance(grid, list) or not grid:
+        return None
+    if not all(isinstance(row, list) and row for row in grid):
+        return None
+
+    try:
+        normalized = [[int(cell) for cell in row] for row in grid]
+    except Exception:
+        return None
+    width = len(normalized[0])
+    if any(len(row) != width for row in normalized):
+        return None
+    if any(cell < 0 or cell > 9 for row in normalized for cell in row):
+        return None
+    return normalized
+
+
+def _render_grid(grid, label, cell_size=18, padding=8):
+    font = ImageFont.load_default()
+    width = len(grid[0])
+    height = len(grid)
+    label_height = 16
+    image = Image.new('RGB', (width * cell_size + padding * 2, height * cell_size + padding * 2 + label_height), 'white')
+    draw = ImageDraw.Draw(image)
+    draw.text((padding, 0), label, fill='black', font=font)
+    top = padding + label_height
+    for row_idx, row in enumerate(grid):
+        for col_idx, cell in enumerate(row):
+            x0 = padding + col_idx * cell_size
+            y0 = top + row_idx * cell_size
+            x1 = x0 + cell_size
+            y1 = y0 + cell_size
+            draw.rectangle([x0, y0, x1, y1], fill=ARC_COLORS[int(cell)], outline=(180, 180, 180))
+    return image
+
+
+def _compose_task_image(task):
+    sections = []
+    for idx, pair in enumerate(task['train'], start=1):
+        sections.append((_render_grid(pair['input'], f'Train {idx} Input'), _render_grid(pair['output'], f'Train {idx} Output')))
+
+    test_images = []
+    for idx, pair in enumerate(task['test'], start=1):
+        test_images.append(_render_grid(pair['input'], f'Test {idx} Input'))
+
+    row_gap = 16
+    col_gap = 16
+    pair_gap = 28
+    max_width = 0
+    total_height = 24
+
+    row_specs = []
+    for input_image, output_image in sections:
+        row_width = input_image.width + output_image.width + pair_gap
+        row_height = max(input_image.height, output_image.height)
+        row_specs.append(('pair', input_image, output_image, row_width, row_height))
+        max_width = max(max_width, row_width)
+        total_height += row_height + row_gap
+
+    for test_image in test_images:
+        row_specs.append(('test', test_image, None, test_image.width, test_image.height))
+        max_width = max(max_width, test_image.width)
+        total_height += test_image.height + row_gap
+
+    canvas = Image.new('RGB', (max_width + 32, total_height + 8), 'white')
+    draw = ImageDraw.Draw(canvas)
+    draw.text((16, 8), 'ARC-AGI task', fill='black', font=ImageFont.load_default())
+
+    y = 24
+    for kind, left_image, right_image, row_width, row_height in row_specs:
+        x = 16
+        canvas.paste(left_image, (x, y))
+        if kind == 'pair':
+            x += left_image.width + pair_gap // 2
+            draw.text((x - 8, y + row_height // 2 - 6), '->', fill='black', font=ImageFont.load_default())
+            x += pair_gap // 2
+            canvas.paste(right_image, (x, y))
+        y += row_height + row_gap
+
+    return canvas
+
+
+class ARCAGIDataset(ImageBaseDataset):
+    TYPE = 'VQA'
+
+    @classmethod
+    def supported_datasets(cls):
+        return ['ARC-AGI']
+
+    @staticmethod
+    def _repo_root():
+        return Path(__file__).resolve().parents[2] / 'ref_repos' / 'ARC-AGI-2'
+
+    @staticmethod
+    def _task_dir():
+        return ARCAGIDataset._repo_root() / 'data' / 'evaluation'
+
+    def _build_question(self, num_tests):
+        lines = [
+            'Infer the output grid for every test input in the ARC task image.',
+            'Return ONLY valid JSON.',
+        ]
+        if num_tests == 1:
+            lines.append('Format: [[row1], [row2], ...]')
+        else:
+            mapping = ', '.join(f'"test_{idx}"' for idx in range(1, num_tests + 1))
+            lines.append(f'Format: {{{mapping}: [[...]]}}')
+        lines.append('Every grid cell must be an integer between 0 and 9.')
+        return '\n'.join(lines)
+
+    def load_data(self, dataset):
+        assert dataset == 'ARC-AGI'
+        cache_path = Path(LMUDataRoot()) / 'ARC-AGI.tsv'
+        image_root = Path(LMUDataRoot()) / 'images' / 'ARC-AGI'
+        image_root.mkdir(parents=True, exist_ok=True)
+
+        if cache_path.exists():
+            return load(str(cache_path))
+
+        rows = []
+        for task_file in sorted(self._task_dir().glob('*.json')):
+            task = json.load(open(task_file, 'r', encoding='utf-8'))
+            task_id = task_file.stem
+            image_path = image_root / f'{task_id}.png'
+            if not image_path.exists():
+                _compose_task_image(task).save(image_path)
+
+            answer = {}
+            for idx, pair in enumerate(task['test'], start=1):
+                key = f'test_{idx}'
+                answer[key] = pair['output']
+
+            rows.append({
+                'index': task_id,
+                'task_id': task_id,
+                'question': self._build_question(len(task['test'])),
+                'image_path': str(image_path),
+                'answer': json.dumps(answer if len(answer) > 1 else answer['test_1'], ensure_ascii=False),
+                'num_tests': len(task['test']),
+            })
+
+        data = pd.DataFrame(rows)
+        dump(data, str(cache_path))
+        return data
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        data = load(eval_file)
+        hits = []
+        parsed_predictions = []
+
+        for _, row in data.iterrows():
+            expected_raw = json.loads(row['answer'])
+            expected = _normalize_grid(expected_raw)
+            predicted = _normalize_grid(str(row.get('prediction', '')))
+
+            if isinstance(expected, dict):
+                is_hit = isinstance(predicted, dict) and expected == predicted
+            else:
+                if isinstance(predicted, dict) and 'test_1' in predicted:
+                    predicted = predicted['test_1']
+                is_hit = expected == predicted
+
+            hits.append(1.0 if is_hit else 0.0)
+            parsed_predictions.append(json.dumps(predicted, ensure_ascii=False) if predicted is not None else '')
+
+        data = data.copy()
+        data['pred_parsed'] = parsed_predictions
+        data['hit'] = hits
+
+        detail_file = get_intermediate_file_path(eval_file, '_results')
+        dump(data, detail_file)
+
+        summary = {
+            'overall_task_accuracy': float(sum(hits) / len(hits) * 100.0) if hits else 0.0,
+            'num_tasks': int(len(hits)),
+        }
+        score_file = get_intermediate_file_path(eval_file, '_score', 'json')
+        dump(summary, score_file)
+        return summary

--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -261,9 +261,13 @@ class Refocus(ImageBaseDataset):
 class VSPOriginalDataset(ImageBaseDataset):
     TYPE = 'VQA'
     DATASET_URL = {
-        'VSP_maze_task_main_original': 'https://huggingface.co/datasets/luckychao/vlmevalkit_tsv/resolve/main/VSP_maze_task_main_original.tsv'
+        'VSP': 'https://huggingface.co/datasets/luckychao/vlmevalkit_tsv/resolve/main/VSP_maze_task_main_original.tsv',
+        'VSP-in': 'https://huggingface.co/datasets/luckychao/vlmevalkit_tsv/resolve/main/VSP_maze_task_main_original.tsv',
+        'VSP_maze_task_main_original': 'https://huggingface.co/datasets/luckychao/vlmevalkit_tsv/resolve/main/VSP_maze_task_main_original.tsv',
     }
     DATASET_MD5 = {
+        'VSP': 'd52eb0fa0b92c7110bc29d12e0fe688c',
+        'VSP-in': 'd52eb0fa0b92c7110bc29d12e0fe688c',
         'VSP_maze_task_main_original': 'd52eb0fa0b92c7110bc29d12e0fe688c'
     }
 
@@ -481,10 +485,124 @@ class OCRBench(ImageBaseDataset):
 class MathVista(ImageBaseDataset):
     TYPE = 'VQA'
     DATASET_URL = {
+        'MathVista':
+        '',
         'MathVista_MINI':
         'https://opencompass.openxlab.space/utils/VLMEval/MathVista_MINI.tsv'
     }
     DATASET_MD5 = {'MathVista_MINI': 'f199b98e178e5a2a20e7048f5dcb0464'}
+
+    @classmethod
+    def supported_datasets(cls):
+        return ['MathVista', 'MathVista_MINI']
+
+    @staticmethod
+    def _official_mathvista_root():
+        from pathlib import Path
+
+        return Path(__file__).resolve().parents[2] / 'ref_repos' / 'MathVista'
+
+    @classmethod
+    def _ensure_mathvista_images(cls):
+        from pathlib import Path
+        import zipfile
+
+        from ..smp.file import download_file
+
+        repo_root = cls._official_mathvista_root()
+        repo_images = repo_root / 'images'
+        if repo_images.exists():
+            return repo_images
+
+        cache_root = Path(LMUDataRoot()) / 'images' / 'MathVista'
+        if cache_root.exists() and any(cache_root.glob('*.jpg')):
+            return cache_root
+
+        cache_root.mkdir(parents=True, exist_ok=True)
+        zip_path = cache_root / 'images.zip'
+        if not zip_path.exists():
+            download_file('https://huggingface.co/datasets/AI4Math/MathVista/resolve/main/images.zip', str(zip_path))
+
+        with zipfile.ZipFile(zip_path, 'r') as zf:
+            for info in zf.infolist():
+                if info.is_dir():
+                    continue
+                parts = [part for part in Path(info.filename).parts if part not in ('', '.', 'images')]
+                if not parts:
+                    continue
+                dest = cache_root.joinpath(*parts)
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(info, 'r') as src, open(dest, 'wb') as dst:
+                    dst.write(src.read())
+        return cache_root
+
+    @classmethod
+    def _build_official_tsv(cls, dataset):
+        import json
+        from pathlib import Path
+
+        split_name = 'test' if dataset == 'MathVista' else 'testmini'
+        repo_root = cls._official_mathvista_root()
+        data_path = repo_root / 'data' / f'{split_name}.json'
+        query_path = repo_root / 'data' / 'query.json'
+        if not data_path.exists() or not query_path.exists():
+            raise FileNotFoundError(f'Official MathVista data not found under {repo_root}')
+
+        image_root = cls._ensure_mathvista_images()
+        cache_path = Path(LMUDataRoot()) / f'{dataset}.tsv'
+
+        problems = json.load(open(data_path, 'r', encoding='utf-8'))
+        queries = json.load(open(query_path, 'r', encoding='utf-8'))
+
+        rows = []
+        for pid, item in problems.items():
+            metadata = item.get('metadata', {})
+            choices = item.get('choices') or []
+            answer = item.get('answer')
+            answer_option = ''
+            if item.get('question_type') == 'multi_choice' and choices and answer in choices:
+                answer_option = chr(ord('A') + choices.index(answer))
+
+            image_rel = Path(item['image'])
+            if image_rel.parts and image_rel.parts[0] == 'images':
+                image_rel = Path(*image_rel.parts[1:])
+            image_path = image_root / image_rel
+
+            rows.append({
+                'index': str(pid),
+                'pid': str(item.get('pid', pid)),
+                'question': queries.get(str(pid), item.get('question', '')),
+                'question_type': item.get('question_type', ''),
+                'answer_type': item.get('answer_type', ''),
+                'precision': item.get('precision', 0) if item.get('precision', None) is not None else 0,
+                'answer': answer,
+                'answer_option': answer_option,
+                'choices': repr(choices),
+                'unit': item.get('unit', '') or '',
+                'image_path': str(image_path),
+                'split': metadata.get('split', split_name),
+                'language': metadata.get('language', ''),
+                'source': metadata.get('source', ''),
+                'category': metadata.get('category', ''),
+                'task': metadata.get('task', ''),
+                'context': metadata.get('context', ''),
+                'grade': metadata.get('grade', ''),
+                'skills': repr(metadata.get('skills', [])),
+            })
+
+        data = pd.DataFrame(rows)
+        dump(data, str(cache_path))
+        return data
+
+    def load_data(self, dataset):
+        from pathlib import Path
+
+        if dataset in ('MathVista', 'MathVista_MINI'):
+            cache_path = Path(LMUDataRoot()) / f'{dataset}.tsv'
+            if cache_path.exists():
+                return load(str(cache_path))
+            return self._build_official_tsv(dataset)
+        return super().load_data(dataset)
 
     def evaluate(self, eval_file, **judge_kwargs):
         if judge_kwargs.get('use_verifier', False):
@@ -3816,11 +3934,15 @@ class AyaVisionBench(ImageVQADataset):
 class MathCanvas(ImageBaseDataset):
     TYPE = 'VQA'
     DATASET_URL = {
+        "MathCanvas-in": "https://huggingface.co/datasets/shiwk24/MathCanvas-Bench/resolve/main/MathCanvas_Bench_VLMEvalKit.tsv",
+        "MathCanvas-in (3k)": "https://huggingface.co/datasets/shiwk24/MathCanvas-Bench/resolve/main/MathCanvas_Bench_VLMEvalKit.tsv",
         "MathCanvas-Bench":
         "https://huggingface.co/datasets/shiwk24/MathCanvas-Bench/resolve/main/MathCanvas_Bench_VLMEvalKit.tsv"
     }
     DATASET_MD5 = {
-        "MathCanvas-Bench": "9fd0b783ca416dbb20ecfb04d2711411"
+        "MathCanvas-in": "827dd1b1ce9c17d2b8338af6a13b6791",
+        "MathCanvas-in (3k)": "827dd1b1ce9c17d2b8338af6a13b6791",
+        "MathCanvas-Bench": "827dd1b1ce9c17d2b8338af6a13b6791"
     }
 
     HINT = (

--- a/vlmeval/dataset/mindcubebench.py
+++ b/vlmeval/dataset/mindcubebench.py
@@ -1,0 +1,112 @@
+import ast
+import os
+
+from huggingface_hub import snapshot_download
+from tqdm import tqdm
+
+from .image_mcq import ImageMCQDataset
+from ..smp.file import load
+from ..smp.misc import get_cache_path, modelscope_flag_set, toliststr
+
+
+class MindCubeBench(ImageMCQDataset):
+    TYPE = 'MCQ'
+
+    RAW_URL = 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/MindCubeBench_raw_qa.tsv'
+    TINY_URL = 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/MindCubeBench_tiny_raw_qa.tsv'
+
+    DATASET_URL = {
+        'MindCube': RAW_URL,
+        'MindCubeBench': RAW_URL,
+        'MindCubeBench_raw_qa': RAW_URL,
+        'MindCubeBench_tiny_raw_qa': TINY_URL,
+    }
+    DATASET_MD5 = {
+        'MindCube': '6a53cd353bc93d8e3a87098249c806ad',
+        'MindCubeBench': '6a53cd353bc93d8e3a87098249c806ad',
+        'MindCubeBench_raw_qa': '6a53cd353bc93d8e3a87098249c806ad',
+        'MindCubeBench_tiny_raw_qa': '35f69fc30d7c2d2880417ce0769f5347',
+    }
+
+    def _task_category(self):
+        return ['rotation', 'among', 'around']
+
+    def prepare_tsv(self, url, file_md5=None, repo_id='MLL-Lab/MindCube'):
+        data = super().prepare_tsv(url, file_md5)
+
+        sentinel_name = '.mindcubebench_extracted'
+        cache_path = get_cache_path(repo_id)
+        if cache_path and os.path.isdir(cache_path) and os.path.isfile(os.path.join(cache_path, sentinel_name)):
+            dataset_path = cache_path
+        else:
+            if modelscope_flag_set():
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+
+            zip_files = sorted(
+                os.path.join(dataset_path, filename)
+                for filename in os.listdir(dataset_path)
+                if filename.endswith('.zip')
+            )
+            for zip_file in tqdm(zip_files, desc='Unpacking MindCube data'):
+                import zipfile
+
+                with zipfile.ZipFile(zip_file, 'r') as zf:
+                    zf.extractall(dataset_path)
+            with open(os.path.join(dataset_path, sentinel_name), 'w', encoding='utf-8') as f:
+                f.write('done')
+
+        if 'image_path' in data.columns:
+            def fix_one(value):
+                if not isinstance(value, str):
+                    return value
+                normalized = os.path.expanduser(os.path.expandvars(value.strip()))
+                return os.path.normpath(os.path.join(dataset_path, normalized.lstrip(r'\/')))
+
+            def to_abs(value):
+                if isinstance(value, list):
+                    return [fix_one(item) for item in value]
+                if isinstance(value, str) and value.strip().startswith('[') and value.strip().endswith(']'):
+                    try:
+                        parsed = ast.literal_eval(value)
+                    except Exception:
+                        parsed = None
+                    if isinstance(parsed, list):
+                        return [fix_one(item) for item in parsed]
+                return fix_one(value)
+
+            data['image_path'] = data['image_path'].map(to_abs)
+
+        return data
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        tgt_path = toliststr(line['image_path']) if self.meta_only else self.dump_image(line)
+        prompt = line['input_prompt']
+        images = tgt_path if isinstance(tgt_path, list) else [tgt_path]
+        parts = prompt.split('<image>')
+
+        messages = []
+        for idx, part in enumerate(parts):
+            part = part.strip()
+            if part:
+                messages.append(dict(type='text', value=part))
+            if idx < len(parts) - 1 and idx < len(images):
+                messages.append(dict(type='image', value=images[idx]))
+        return [message for message in messages if message['value']]
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        from .utils.spatial_bench.cal_scores import build_mcq_score_fn, eval_mcq_score
+
+        return eval_mcq_score(
+            load_fn=load,
+            eval_file=eval_file,
+            score_fn=build_mcq_score_fn(**judge_kwargs),
+            group_col='category',
+            order=self._task_category(),
+            dataset_name=getattr(self, 'dataset_name', 'MindCubeBench'),
+        )

--- a/vlmeval/dataset/mmsibench.py
+++ b/vlmeval/dataset/mmsibench.py
@@ -1,0 +1,79 @@
+import string
+
+import pandas as pd
+
+from .image_mcq import ImageMCQDataset
+from ..smp.file import load
+from ..smp.misc import toliststr
+
+
+class MMSIBench(ImageMCQDataset):
+    TYPE = 'MCQ'
+
+    MMSI_URL = 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/MMSIBench_wo_circular.tsv'
+
+    DATASET_URL = {
+        'MMSI': MMSI_URL,
+        'MMSIBench': MMSI_URL,
+        'MMSIBench_wo_circular': MMSI_URL,
+    }
+    DATASET_MD5 = {
+        'MMSI': '548c5f33f1a12948d5355d5f600749e4',
+        'MMSIBench': '548c5f33f1a12948d5355d5f600749e4',
+        'MMSIBench_wo_circular': '548c5f33f1a12948d5355d5f600749e4',
+    }
+
+    def _task_category(self):
+        return [
+            'Pos-Cam-Cam',
+            'Pos-Obj-Obj',
+            'Pos-Reg-Reg',
+            'Pos-Cam-Obj',
+            'Pos-Obj-Reg',
+            'Pos-Cam-Reg',
+            'Attr-Meas',
+            'Attr-Appr',
+            'Motion-Cam',
+            'Motion-Obj',
+            'MSR',
+        ]
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        tgt_path = toliststr(line['image_path']) if self.meta_only else self.dump_image(line)
+        question = line['question']
+        options = {
+            cand: line[cand]
+            for cand in string.ascii_uppercase
+            if cand in line and not pd.isna(line[cand])
+        }
+
+        prompt = ''
+        if 'hint' in line and not pd.isna(line['hint']):
+            prompt += f"Hint: {line['hint']}\n"
+        prompt += f'{question}\n'
+        if options:
+            prompt += 'Options: ' + ', '.join(f'{key}: {value}' for key, value in options.items()) + '\n'
+        prompt += "Answer with the option's letter from the given choices directly. Enclose the option's letter within ``."
+
+        messages = []
+        if isinstance(tgt_path, list):
+            messages.extend(dict(type='image', value=path) for path in tgt_path)
+        else:
+            messages.append(dict(type='image', value=tgt_path))
+        messages.append(dict(type='text', value=prompt))
+        return messages
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        from .utils.spatial_bench.cal_scores import build_mcq_score_fn, eval_mcq_score
+
+        return eval_mcq_score(
+            load_fn=load,
+            eval_file=eval_file,
+            score_fn=build_mcq_score_fn(**judge_kwargs),
+            group_col='category',
+            order=self._task_category(),
+            dataset_name=getattr(self, 'dataset_name', 'MMSIBench'),
+        )

--- a/vlmeval/dataset/utils/spatial_bench/__init__.py
+++ b/vlmeval/dataset/utils/spatial_bench/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for spatial benchmark scoring."""

--- a/vlmeval/dataset/utils/spatial_bench/cal_scores.py
+++ b/vlmeval/dataset/utils/spatial_bench/cal_scores.py
@@ -1,0 +1,85 @@
+from collections import OrderedDict
+
+import pandas as pd
+
+from .matching_func import can_match_option
+from ....smp.file import dump, get_intermediate_file_path
+
+
+def compute_mcq_score(df: pd.DataFrame) -> pd.DataFrame:
+    preds_extracted = []
+    hits = []
+
+    for _, row in df.iterrows():
+        pred_raw = str(row.get('prediction', ''))
+        gt_raw = str(row.get('answer', '')).strip()
+        pred = can_match_option(pred_raw)
+        gt = can_match_option(gt_raw)
+        preds_extracted.append(pred)
+        hits.append(1.0 if pred and gt and pred == gt else 0.0)
+
+    scored = df.copy()
+    scored['pred_extracted'] = preds_extracted
+    scored['hit'] = hits
+    return scored
+
+
+def build_mcq_score_fn(**judge_kwargs):
+    def score_fn(df: pd.DataFrame) -> pd.DataFrame:
+        return compute_mcq_score(df)
+
+    score_fn.judge_mode = 'rule'
+    score_fn.judge_model = judge_kwargs.get('model', 'extract_matching')
+    return score_fn
+
+
+def _ordered_categories(scored: pd.DataFrame, group_col: str, order=None):
+    if group_col not in scored.columns:
+        return []
+    present = [cat for cat in scored[group_col].dropna().unique().tolist()]
+    if order is None:
+        return present
+    preferred = [cat for cat in order if cat in present]
+    remaining = [cat for cat in present if cat not in preferred]
+    return preferred + remaining
+
+
+def eval_mcq_score(
+    *,
+    load_fn,
+    eval_file: str,
+    score_fn,
+    group_col='category',
+    order=None,
+    dataset_name='MCQ',
+):
+    data = load_fn(eval_file)
+    if 'index' in data.columns:
+        data = data.sort_values(by='index')
+    data['prediction'] = [str(x) for x in data['prediction']]
+
+    scored = score_fn(data.copy())
+
+    detail_path = get_intermediate_file_path(eval_file, '_extract_matching', 'xlsx')
+    dump(scored, detail_path)
+
+    summary = OrderedDict()
+    summary['overall'] = float(scored['hit'].mean() * 100.0) if len(scored) else 0.0
+
+    if isinstance(group_col, str):
+        group_cols = [group_col]
+    else:
+        group_cols = list(group_col)
+
+    for gc in group_cols:
+        categories = _ordered_categories(scored, gc, order if gc == group_cols[0] else None)
+        prefix = '' if len(group_cols) == 1 else f'{gc}.'
+        for category in categories:
+            subset = scored[scored[gc] == category]
+            if len(subset):
+                summary[f'{prefix}{category}_accuracy'] = float(subset['hit'].mean() * 100.0)
+
+    score_path = get_intermediate_file_path(eval_file, '_score', 'json')
+    dump(summary, score_path)
+    print(f'[{dataset_name}] summary: {summary}')
+    return summary

--- a/vlmeval/dataset/utils/spatial_bench/matching_func.py
+++ b/vlmeval/dataset/utils/spatial_bench/matching_func.py
@@ -1,0 +1,50 @@
+import re
+
+
+def can_match_option(answer_text, choices=None, tail_lines=6, tail_window=800):
+    if not isinstance(answer_text, str):
+        return False
+
+    text = answer_text.strip()
+    letters = 'ABCDEFGHIJ'
+    if choices:
+        allowed = {str(choice).strip().upper()[:1] for choice in choices if str(choice).strip()}
+        letters = ''.join(ch for ch in letters if ch in allowed) or 'ABCDEF'
+    else:
+        letters = 'ABCDEF'
+
+    block_pattern = re.compile(
+        rf'<\s*answer\b[^>]*>\s*([{letters}])(?:\s*[\.．:：\)\]】、])?.*?<\s*/\s*answer\s*>',
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    match = block_pattern.search(text)
+    if match:
+        return match.group(1).upper()
+
+    phrase_pattern = re.compile(
+        rf'(?i)(?:final\s*answer|the\s*answer\s*is|answer(?:\s*is)?|correct\s*answer|'
+        rf'答案|最终答案|结论|所以|因此|我选(?:择)?|选择|选)\s*[:：>＝=]?\s*'
+        rf'[\(\[\{{（【]?\s*([{letters}])\s*[\)\]\}}）】]?(?:\b|[.)、。])'
+    )
+    match = phrase_pattern.search(text[-tail_window:])
+    if match:
+        return match.group(1).upper()
+
+    line_patterns = [
+        re.compile(rf'^\s*[*_`>（）\[\]【】\(\)]*\s*([{letters}])\s*[*_`（）\[\]【】\(\)]*\s*$'),
+        re.compile(rf'^\s*([{letters}])\s*[\.．:：\)\]】、-]\s+', flags=re.IGNORECASE),
+    ]
+    tail_segment = text[-tail_window:].splitlines()[-tail_lines:]
+    for line in reversed([line.strip() for line in tail_segment if line.strip()]):
+        for pattern in line_patterns:
+            match = pattern.match(line)
+            if match:
+                return match.group(1).upper()
+
+    token_pattern = re.compile(rf'(?<![A-Za-z])([{letters}])(?![A-Za-z])')
+    tokens = [token.upper() for token in token_pattern.findall(text)]
+    unique_tokens = sorted(set(tokens))
+    if len(unique_tokens) == 1:
+        return unique_tokens[0]
+
+    return False


### PR DESCRIPTION
I added some implementation of benchmarks into this framework.


| No. | Benchmark            | Category   | Importance | 当前实现进度 | 原始仓库支持情况 | 官方VLMEvalKit实现 | 仓库对应名称/说明 | 官方实现/代码 |
|-----|----------------------|------------|------------|--------------|------------------|--------------------|-------------------|---------------|
| 1   | MathCanvas-in (3k)   | Math       | 0          | ✓ | 暂不支持（仅 `MathCanvas-Bench`） | 暂不支持（仅 `MathCanvas-Bench`） | 当前仓库新增兼容名称 `MathCanvas-in`、`MathCanvas-in (3k)`，实际映射到官方公开的 `MathCanvas-Bench` 3K benchmark | [MathCanvas](https://github.com/shiwk24/MathCanvas) |
| 2   | MathVision           | Math       | 0          | ✓ | 支持 | 支持 | `MathVision`、`MathVision_MINI` | [MATH-V / MathVision](https://github.com/mathllm/MATH-V) |
| 3   | MathVista            | Math       | 0          | ✓ | 暂不支持（仅 `MathVista_MINI`） | 暂不支持（仅 `MathVista_MINI`） | 当前仓库新增完整 `MathVista` 本地官方数据接入，同时保留 `MathVista_MINI` | [MathVista](https://github.com/lupantech/MathVista) |
| 4   | VSP / VSP-in         | Spatial    | 0          |  | 暂不支持（仅 `VSP_maze_task_main_original`） | 暂不支持 | 当前仓库新增 `VSP`、`VSP-in` 命名兼容，但底层仍对应官方已公开的 `VSP_maze_task_main_original` maze split；官方仓库暂未公开完整 benchmark 数据 | [VisualPlanning](https://github.com/yix8/VisualPlanning) |
| 5   | MindCube             | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库新增 `MindCube`、`MindCubeBench`、`MindCubeBench_raw_qa`、`MindCubeBench_tiny_raw_qa` | [MindCube](https://github.com/mll-lab-nu/MindCube) |
| 6   | MMSI                 | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库新增 `MMSI`、`MMSIBench`、`MMSIBench_wo_circular`；`MMSI` 默认映射官方 non-circular 评测集 | [MMSI-Bench](https://github.com/OpenRobotLab/MMSI-Bench) |
| 7   | EMMA                 | General    | 0          | ✓ | 支持 | 支持 | `EMMA`、`EMMA_COT` | [EMMA](https://github.com/EMMA-Bench/EMMA) |
| 8   | V*StarBench          | Perception | 0          | ✓ | 支持 | 支持 | `VStarBench` | [V* / VStarBench](https://github.com/penghao-wu/vstar) |
| 9   | HRBench              | Perception | 0          | ✓ | 支持 | 支持 | `HRBench4K`、`HRBench8K` | [HR-Bench](https://github.com/DreamMr/HR-Bench) |
| 10  | CVBench              | Perception | 0          | ✓ | 支持 | 支持 | `CV-Bench-2D`、`CV-Bench-3D` | [Cambrian / CV-Bench](https://github.com/cambrian-mllm/cambrian) |
| 11  | MMVP                 | Perception | 0          | ✓ | 支持 | 支持 | `MMVP` | [MMVP](https://github.com/tsb0601/MMVP) |
| 12  | BLINK                | Perception | 0          | ✓ | 支持 | 支持 | `BLINK`、`BLINK_circular`，另含 `BLINK_Jigsaw` | [BLINK](https://github.com/zeyofu/BLINK_Benchmark) |
| 13  | MMMU                 | General    | 0          | ✓ | 支持 | 支持 | `MMMU_DEV_VAL`、`MMMU_TEST`，另含 `MMMU_Pro_*` | [MMMU](https://github.com/MMMU-Benchmark/MMMU) |
| 14  | ScienceQA            | General    | 0          | ✓ | 支持 | 支持 | `ScienceQA_VAL`、`ScienceQA_TEST` | [ScienceQA](https://github.com/lupantech/ScienceQA) |
| 15  | ARC-AGI              | General    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增 `ARC-AGI`：基于官方 `ARC-AGI-2` public evaluation JSON 渲染任务图，要求模型输出 JSON grid，并做 exact-match task-level eval | [ARC-AGI-2](https://github.com/arcprize/ARC-AGI-2) |