### PR TITLE
Add New Benchmarks

### DIFF
--- a/bench_info.md
+++ b/bench_info.md
@@ -17,6 +17,22 @@
 | 13  | MMMU                 | General    | 0          | ✓ | 支持 | 支持 | `MMMU_DEV_VAL`、`MMMU_TEST`，另含 `MMMU_Pro_*` | [MMMU](https://github.com/MMMU-Benchmark/MMMU) |
 | 14  | ScienceQA            | General    | 0          | ✓ | 支持 | 支持 | `ScienceQA_VAL`、`ScienceQA_TEST` | [ScienceQA](https://github.com/lupantech/ScienceQA) |
 | 15  | ARC-AGI              | General    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增 `ARC-AGI`：基于官方 `ARC-AGI-2` public evaluation JSON 渲染任务图，要求模型输出 JSON grid，并做 exact-match task-level eval | [ARC-AGI-2](https://github.com/arcprize/ARC-AGI-2) |
+| 16  | MathVerse            | Math       | 0          | ✓ | 暂不支持（仅 `MathVerse_MINI` 系列） | 暂不支持（仅 `MathVerse_MINI` 系列） | 当前仓库新增 `MathVerse` 官方 public 数据接入，实际基于官方 HF 公开的 `testmini`（3940 samples）构建；仍不等同于未公开的完整全量集 | [MathVerse](https://github.com/ZrrSkywalker/MathVerse) |
+| 17  | OmniSpatial          | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，新增别名 `OmniSpatial`，默认映射到 `OmniSpatialBench`；同时支持 `OmniSpatialBench_default`、`OmniSpatialBench_zeroshot_cot`、`OmniSpatialBench_manual_cot` | [OmniSpatial](https://github.com/qizekun/OmniSpatial) |
+| 18  | Super-CLEVR          | Spatial    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增官方 HF 数据接入，基于 `images.zip + superCLEVR_questions_30k.json` 构建 `Super-CLEVR` 数据集并做短答 exact-match eval | [Super-CLEVR](https://github.com/Lizw14/Super-CLEVR) |
+| 19  | SITE                 | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，新增别名 `SITE`、`SITE-Image`，默认映射到 `SiteBenchImage`；同时支持 `SiteBenchVideo_32frame`、`SiteBenchVideo_64frame`、`SiteBenchVideo_1fps`，其中 video 评测依赖 `decord` | [SITE-Bench](https://github.com/wenqi-wang20/SITE-Bench) |
+| 20  | SpatialViz-Bench     | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，新增别名 `SpatialViz-Bench`，默认映射到 `SpatialVizBench`；同时支持 `SpatialVizBench_CoT` | [SpatialViz-Bench](https://github.com/wangst0181/SpatialViz-Bench) |
+| 21  | ViewSpatial-Bench    | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，新增别名 `ViewSpatial-Bench`，默认映射到 `ViewSpatialBench` | [ViewSpatial-Bench](https://github.com/ZJU-REAL/ViewSpatial-Bench) |
+| 22  | 3DSRBench            | Spatial    | 0          | ✓ | 支持 | 支持 | `3DSRBench`；官方公开可获取形式主要是 HuggingFace dataset repo，当前已按该源 clone | [3DSRBench](https://huggingface.co/datasets/ccvl/3DSRBench) |
+| 23  | All-Angles Bench     | Spatial    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增 `All_Angles_Bench`，并兼容别名 `All-Angles Bench` / `All-Angles-Bench`；数据按官方 HF `data.json` 自动转成 TSV，多图 MCQ eval 复用框架通用流程 | [All-Angles Bench](https://github.com/Chenyu-Wang567/All-Angles-Bench) |
+| 24  | ERQA                 | Embodied   | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，支持 `ERQA` / `ERQABench` 评测流程 | [ERQA](https://github.com/embodiedreasoning/ERQA) |
+| 25  | Embodied-bench       | Embodied   | 0          |  | 暂不支持（仅 `StaticEmbodiedBench`） | 暂不支持（仅 `StaticEmbodiedBench`） | 当前仓库与官方 VLMEvalKit 仅内置 `StaticEmbodiedBench`、`StaticEmbodiedBench_circular`，不等同于完整 `EmbodiedBench` agent benchmark | [EmbodiedBench](https://github.com/EmbodiedBench/EmbodiedBench) |
+| 26  | SEED-Bench-2-Plus    | Perception | 0          | ✓ | 支持 | 支持 | `SEEDBench2_Plus` | [SEED-Bench](https://github.com/AILab-CVC/SEED-Bench) |
+| 27  | MME-RealWorld-Lite   | Perception | 0          | ✓ | 支持 | 支持 | `MME-RealWorld-Lite`，另含 `MME-RealWorld`、`MME-RealWorld-CN` | [MME-RealWorld](https://github.com/MME-Benchmarks/MME-RealWorld) |
+| 28  | RealWorldQA          | Perception | 0          | ✓ | 支持 | 支持 | `RealWorldQA` | [RealWorldQA](https://huggingface.co/datasets/xai-org/RealworldQA) |
+| 29  | MMStar               | General    | 0          | ✓ | 支持 | 支持 | `MMStar`，另含 `MMStar_KO`、`MMStar_TR`、`MMStar_MINI` | [MMStar](https://github.com/MMStar-Benchmark/MMStar) |
+| 30  | TRI-Bench            | General    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增 `TRI-Bench`：复用官方 prompt 与官方 `3D/2D` 评分公式，对每张图输出六个 JSON 字段，并汇总 `overall_3d_accuracy / overall_2d_accuracy` | [TRI-Bench](https://github.com/Amiton7/Tri-Bench) |
+| 31  | OrderBench           | General    | 0          |  | 暂不支持 | 暂不支持 | 当前仓库与官方 VLMEvalKit 均暂未发现内置实现；暂未检索到可靠公开官方代码 | 暂未找到可靠公开官方代码 |
 
 ### 本地已跑结果汇总
 

--- a/vlmeval/dataset/__init__.py
+++ b/vlmeval/dataset/__init__.py
@@ -74,8 +74,16 @@ from .mmmath import MMMath
 from .dynamath import Dynamath
 from .creation import CreationMMBenchDataset
 from .mmalignbench import MMAlignBench
+from .mindcubebench import MindCubeBench
+from .mmsibench import MMSIBench
+from .arc_agi import ARCAGIDataset
+from .omnispatialbench import OmniSpatialBench
+from .sitebench import SiteBenchImage, SiteBenchVideo
+from .spatialvizbench import SpatialVizBench
+from .viewspatialbench import ViewSpatialBench
+from .erqabench import ERQABench
+from .official_extra_benches import AllAnglesBench, SuperCLEVRBench, TriBenchDataset
 from .utils import *
-from .video_dataset_config import *
 from ..smp import *
 from .OmniDocBench.omnidocbench import OmniDocBench
 from .moat import MOAT
@@ -93,9 +101,7 @@ from .medqbench_paired_description import MedqbenchPairedDescriptionDataset
 from .olmOCRBench.olmocrbench import olmOCRBench
 from .oceanocr import OceanOCRBench
 from .matbench import MATBench
-from .mindcubebench import MindCubeBench
-from .mmsibench import MMSIBench
-from .arc_agi import ARCAGIDataset
+from .video_dataset_config import *
 
 from .reasonmap_plus import ReasonMap_Plus
 from .hipho import HiPhODataset
@@ -233,7 +239,9 @@ IMAGE_DATASET = [
     AyaVisionBench, TopViewRS, VLMBias, MMHELIX, MedqbenchMCQDataset, MathCanvas, MMReason,
     MedqbenchPairedDescriptionDataset, MedqbenchCaptionDataset, ChartMuseum, ChartQAPro, ReasonMap_Plus,
     olmOCRBench, OceanOCRBench, MATBench, VLRMBench, RefCOCODataset, SimpleVQA, HiPhODataset, MaCBench,
-    UniSVG, SArena_MINI, Refocus, VSPOriginalDataset, MindCubeBench, MMSIBench, ARCAGIDataset
+    UniSVG, SArena_MINI, Refocus, VSPOriginalDataset, MindCubeBench, MMSIBench, ARCAGIDataset,
+    OmniSpatialBench, SiteBenchImage, SpatialVizBench, ViewSpatialBench, ERQABench,
+    AllAnglesBench, SuperCLEVRBench, TriBenchDataset
 ]
 
 VIDEO_DATASET = [
@@ -245,7 +253,7 @@ VIDEO_DATASET = [
     QBench_Video, QBench_Video_MCQ, QBench_Video_VQA,
     Video_MMLU_CAP, Video_MMLU_QA,
     Video_Holmes, VCRBench, CGAVCounting,
-    EgoExoBench_MCQ, DREAM, VideoTT, VideoMMMU, VSIBench
+    EgoExoBench_MCQ, DREAM, VideoTT, VideoMMMU, VSIBench, SiteBenchVideo
 
 ]
 
@@ -260,12 +268,40 @@ CUSTOM_DATASET = [
 DATASET_COLLECTION = [ConcatDataset, ConcatVideoDataset]
 
 DATASET_CLASSES = IMAGE_DATASET + VIDEO_DATASET + TEXT_DATASET + CUSTOM_DATASET + DATASET_COLLECTION  # noqa: E501
+DATASET_ALIASES = {
+    'OmniSpatial': 'OmniSpatialBench',
+    'SITE': 'SiteBenchImage',
+    'SITE-Image': 'SiteBenchImage',
+    'SITE-Video': 'SiteBenchVideo_32frame',
+    'SpatialViz-Bench': 'SpatialVizBench',
+    'ViewSpatial-Bench': 'ViewSpatialBench',
+    'All-Angles Bench': 'All_Angles_Bench',
+    'All-Angles-Bench': 'All_Angles_Bench',
+}
+
+
+def normalize_dataset_name(dataset_name):
+    if dataset_name is None:
+        return None
+    return DATASET_ALIASES.get(dataset_name, dataset_name)
+
+
 SUPPORTED_DATASETS = []
 for DATASET_CLS in DATASET_CLASSES:
     SUPPORTED_DATASETS.extend(DATASET_CLS.supported_datasets())
+SUPPORTED_DATASETS.extend([name for name in DATASET_ALIASES if name not in SUPPORTED_DATASETS])
+SUPPORTED_DATASETS.extend([name for name in supported_video_datasets if name not in SUPPORTED_DATASETS])
+SUPPORTED_DATASETS = list(dict.fromkeys(SUPPORTED_DATASETS))
 
 
 def DATASET_TYPE(dataset, *, default: str = 'MCQ') -> str:
+    dataset = normalize_dataset_name(dataset)
+    if dataset in supported_video_datasets:
+        dataset_builder = supported_video_datasets[dataset]
+        dataset_cls = getattr(dataset_builder, 'func', dataset_builder)
+        if hasattr(dataset_cls, 'TYPE'):
+            return dataset_cls.TYPE
+        return 'Video-MCQ'
     for cls in DATASET_CLASSES:
         if dataset in cls.supported_datasets():
             if hasattr(cls, 'TYPE'):
@@ -284,9 +320,12 @@ def DATASET_TYPE(dataset, *, default: str = 'MCQ') -> str:
 
 
 def DATASET_MODALITY(dataset, *, default: str = 'IMAGE') -> str:
+    dataset = normalize_dataset_name(dataset)
     if dataset is None:
         warnings.warn(f'Dataset is not specified, will treat modality as {default}. ')
         return default
+    if dataset in supported_video_datasets:
+        return 'VIDEO'
     for cls in DATASET_CLASSES:
         if dataset in cls.supported_datasets():
             if hasattr(cls, 'MODALITY'):
@@ -307,10 +346,12 @@ def DATASET_MODALITY(dataset, *, default: str = 'IMAGE') -> str:
 
 
 def build_dataset(dataset_name, **kwargs):
+    dataset_name = normalize_dataset_name(dataset_name)
+    if dataset_name in supported_video_datasets:
+        return supported_video_datasets[dataset_name](**kwargs)
+
     for cls in DATASET_CLASSES:
-        if dataset_name in supported_video_datasets:
-            return supported_video_datasets[dataset_name](**kwargs)
-        elif dataset_name in cls.supported_datasets():
+        if dataset_name in cls.supported_datasets():
             return cls(dataset=dataset_name, **kwargs)
 
     warnings.warn(f'Dataset {dataset_name} is not officially supported. ')

--- a/vlmeval/dataset/erqabench.py
+++ b/vlmeval/dataset/erqabench.py
@@ -1,0 +1,123 @@
+import json
+import pandas as pd
+
+from ..smp.misc import toliststr
+from ..smp.file import load
+from .image_vqa import ImageVQADataset
+
+
+class ERQABench(ImageVQADataset):
+    """
+    ERQA.
+
+    Reference:
+      Gemini Robotics: Bringing AI into the Physical World
+      https://arxiv.org/html/2503.20020v1
+    """
+
+    DATASET_URL = {
+        'ERQA': 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/ERQA.tsv',
+    }
+    DATASET_MD5 = {
+        'ERQA': '40d45d4f0bb1852dbc68b28ee70d4ca5',
+    }
+
+    def _task_category(self):
+        return [
+            'Action Reasoning',
+            'Multi-view Reasoning',
+            'Pointing',
+            'Spatial Reasoning',
+            'State Estimation',
+            'Task Reasoning',
+            'Trajectory Reasoning',
+            'Other'
+        ]
+
+    def build_prompt(self, line):
+        """
+        Images are interleaved into the question according to visual_indices.
+        """
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        # Resolve image paths
+        if self.meta_only:
+            tgt_paths = toliststr(line['image'])
+        else:
+            tgt_paths = self.dump_image(line)
+
+        question = line['question']
+        vis_raw = line.get('visual_indices', [])
+
+        # Parse visual_indices → List[int]
+        if isinstance(vis_raw, str):
+            try:
+                visual_indices = json.loads(vis_raw)
+            except Exception:
+                parts = [p.strip() for p in vis_raw.strip('[]').split(',') if p.strip()]
+                visual_indices = [int(p) for p in parts] if parts else []
+        elif isinstance(vis_raw, (list, tuple)):
+            visual_indices = list(vis_raw)
+        elif pd.isna(vis_raw):
+            visual_indices = []
+        else:
+            visual_indices = []
+
+        # Mismatch: put all images at the beginning
+        if len(visual_indices) != len(tgt_paths):
+            visual_indices = [0] * len(tgt_paths)
+
+        img_idx_pairs = list(zip(tgt_paths, visual_indices))
+        img_idx_pairs.sort(key=lambda x: x[1])
+
+        msgs = []
+
+        # All images first, then full question
+        if not visual_indices or all(idx == 0 for idx in visual_indices):
+            for p, _ in img_idx_pairs:
+                msgs.append(dict(type='image', value=p))
+            msgs.append(dict(type='text', value=question))
+            return msgs
+
+        # Interleave text and images by character index
+        last_pos = 0
+        for p, idx in img_idx_pairs:
+            if idx == 0:
+                msgs.append(dict(type='image', value=p))
+            else:
+                if idx <= len(question):
+                    seg = question[last_pos:idx]
+                    if seg:
+                        msgs.append(dict(type='text', value=seg))
+                    msgs.append(dict(type='image', value=p))
+                    last_pos = idx
+                else:
+                    msgs.append(dict(type='image', value=p))
+
+        if last_pos < len(question):
+            seg = question[last_pos:]
+            if seg:
+                msgs.append(dict(type='text', value=seg))
+
+        if not msgs:
+            for p, _ in img_idx_pairs:
+                msgs.append(dict(type='image', value=p))
+            msgs.append(dict(type='text', value=question))
+
+        return msgs
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        from .utils.spatial_bench.cal_scores import eval_mcq_score, build_mcq_score_fn
+
+        # Select MCQ scoring function (rule-based or LLM-based) according to judge_kwargs['model'].
+        score_fn = build_mcq_score_fn(**judge_kwargs)
+
+        return eval_mcq_score(
+            load_fn=load,
+            eval_file=eval_file,
+            score_fn=score_fn,
+            group_col='question_type',
+            order=self._task_category(),
+            dataset_name=getattr(self, 'dataset_name', 'ERQA')
+        )

--- a/vlmeval/dataset/image_vqa.py
+++ b/vlmeval/dataset/image_vqa.py
@@ -1,10 +1,14 @@
 import os
 import re
 import tempfile
+import json
+import zipfile
+from pathlib import Path
 from functools import partial
 
 import pandas as pd
 from tqdm import tqdm
+from huggingface_hub import snapshot_download
 
 from .image_base import ImageBaseDataset
 from .utils import build_judge, DEBUG_MESSAGE
@@ -728,6 +732,7 @@ class MathVista(ImageBaseDataset):
 class MathVerse(ImageBaseDataset):
     TYPE = 'VQA'
     DATASET_URL = {
+        'MathVerse': '',
         'MathVerse_MINI':
         'http://opencompass.openxlab.space/utils/benchmarks/MathVerse/MathVerse_MINIV.tsv',  # noqa
         'MathVerse_MINI_Vision_Only':
@@ -752,6 +757,57 @@ class MathVerse(ImageBaseDataset):
         'MathVerse_MINI_Text_Lite': '19e4b13bdd30b89a03b2e358bcfefa04',
         'MathVerse_MINI_Text_Dominant': '4f5cd2fa6630ea00bb11d6fde1f6fe6a',
     }
+
+    def load_data(self, dataset):
+        if dataset == 'MathVerse':
+            return self.prepare_public_mathverse(dataset)
+        return super().load_data(dataset)
+
+    def prepare_public_mathverse(self, dataset):
+        data_root = Path(LMUDataRoot())
+        data_root.mkdir(parents=True, exist_ok=True)
+        data_path = data_root / f'{dataset}.tsv'
+        self.data_path = str(data_path)
+        if data_path.exists():
+            return load(str(data_path))
+
+        repo_path = Path(
+            snapshot_download(
+                repo_id='AI4Math/MathVerse',
+                repo_type='dataset',
+                allow_patterns=['testmini.json', 'images.zip'],
+            )
+        )
+        sentinel = repo_path / '.mathverse_public_extracted'
+        if not sentinel.exists():
+            with zipfile.ZipFile(repo_path / 'images.zip', 'r') as zf:
+                zf.extractall(repo_path)
+            sentinel.write_text('done', encoding='utf-8')
+
+        raw_data = json.loads((repo_path / 'testmini.json').read_text(encoding='utf-8'))
+        rows = []
+        for idx, item in enumerate(raw_data):
+            sample_index = item.get('sample_index', idx)
+            index = int(sample_index) if str(sample_index).isdigit() else idx
+            rows.append(
+                {
+                    'index': index,
+                    'sample_index': sample_index,
+                    'problem_index': item.get('problem_index', ''),
+                    'problem_version': item.get('problem_version', ''),
+                    'question': item.get('query_wo', item.get('question', '')),
+                    'question_for_eval': item.get('question', ''),
+                    'query_cot': item.get('query_cot', item.get('question', '')),
+                    'image_path': str(repo_path / item['image']),
+                    'answer': item.get('answer', ''),
+                    'question_type': item.get('question_type', ''),
+                    'metadata': json.dumps(item.get('metadata', {}), ensure_ascii=False),
+                }
+            )
+
+        data = pd.DataFrame(rows)
+        dump(data, str(data_path))
+        return data
 
     # Given one data record, return the built prompt (a multi-modal message), can override
     def build_prompt(self, line):

--- a/vlmeval/dataset/official_extra_benches.py
+++ b/vlmeval/dataset/official_extra_benches.py
@@ -1,0 +1,409 @@
+import ast
+import json
+import os
+import os.path as osp
+import re
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+from huggingface_hub import snapshot_download
+
+from .image_base import ImageBaseDataset
+from .image_mcq import ImageMCQDataset
+from ..smp import *
+from ..smp.file import LMUDataRoot, dump, get_intermediate_file_path, load
+from ..smp.misc import toliststr
+
+
+def _ensure_zip_extracted(repo_path, zip_name, sentinel_name):
+    repo_path = Path(repo_path)
+    sentinel_path = repo_path / sentinel_name
+    if sentinel_path.exists():
+        return
+
+    zip_path = repo_path / zip_name
+    if not zip_path.exists():
+        raise FileNotFoundError(f'Missing archive: {zip_path}')
+
+    with zipfile.ZipFile(zip_path, 'r') as zf:
+        zf.extractall(repo_path)
+
+    sentinel_path.write_text('done', encoding='utf-8')
+
+
+def _normalize_text(text):
+    text = str(text).strip().lower()
+    text = re.sub(r'^[`\'"\s]+|[`\'"\s]+$', '', text)
+    text = re.sub(r'\s+', ' ', text)
+    return text
+
+
+class AllAnglesBench(ImageMCQDataset):
+    TYPE = 'MCQ'
+    DATASET_URL = {'All_Angles_Bench': ''}
+    DATASET_MD5 = {}
+
+    @staticmethod
+    def _process_question(question, option_a, option_b, option_c):
+        options = [option_a, option_b, option_c]
+        question_no_options = str(question)
+        for option in options:
+            question_no_options = question_no_options.replace(str(option), '')
+        question_no_options = question_no_options.strip().replace(',', '').strip()
+        return question_no_options, options
+
+    def load_data(self, dataset):
+        data_root = Path(LMUDataRoot())
+        data_root.mkdir(parents=True, exist_ok=True)
+        data_path = data_root / f'{self.dataset_name}.tsv'
+        if data_path.exists():
+            self.data_path = str(data_path)
+            return load(str(data_path))
+
+        repo_path = Path(
+            snapshot_download(
+                repo_id='ch-chenyu/All-Angles-Bench',
+                repo_type='dataset',
+            )
+        )
+
+        raw_data = json.loads((repo_path / 'data.json').read_text(encoding='utf-8'))
+        rows = []
+        for entry in raw_data:
+            question, options = self._process_question(
+                entry['question'], entry['A'], entry['B'], entry['C']
+            )
+            image_paths = [str(repo_path / rel_path) for rel_path in entry['image_path']]
+            rows.append(
+                {
+                    'index': int(entry['index']),
+                    'folder': entry['folder'],
+                    'category': entry['category'],
+                    'pair_idx': entry['pair_idx'],
+                    'sourced_dataset': entry.get('sourced_dataset', ''),
+                    'image_path': image_paths,
+                    'question': question,
+                    'A': options[0],
+                    'B': options[1],
+                    'C': options[2],
+                    'answer': entry['answer'],
+                }
+            )
+
+        data = pd.DataFrame(rows)
+        dump(data, str(data_path))
+        self.data_path = str(data_path)
+        return data
+
+
+class SuperCLEVRBench(ImageBaseDataset):
+    TYPE = 'VQA'
+    DATASET_URL = {'Super-CLEVR': ''}
+    DATASET_MD5 = {}
+
+    def load_data(self, dataset):
+        data_root = Path(LMUDataRoot())
+        data_root.mkdir(parents=True, exist_ok=True)
+        data_path = data_root / f'{self.dataset_name}.tsv'
+        if data_path.exists():
+            self.data_path = str(data_path)
+            return load(str(data_path))
+
+        repo_path = Path(
+            snapshot_download(
+                repo_id='RyanWW/Super-CLEVR',
+                repo_type='dataset',
+                allow_patterns=['images.zip', 'superCLEVR_questions_30k.json'],
+            )
+        )
+        _ensure_zip_extracted(repo_path, 'images.zip', '.superclevr_extracted')
+
+        question_file = repo_path / 'superCLEVR_questions_30k.json'
+        questions = json.loads(question_file.read_text(encoding='utf-8'))['questions']
+
+        rows = []
+        for item in questions:
+            candidate_paths = [
+                repo_path / 'images' / item['image_filename'],
+                repo_path / item['image_filename'],
+            ]
+            image_path = next((p for p in candidate_paths if p.exists()), candidate_paths[0])
+            answer = item['answer']
+            rows.append(
+                {
+                    'index': int(item['question_index']),
+                    'image_path': str(image_path),
+                    'question': item['question'],
+                    'answer': str(answer),
+                    'answer_type': type(answer).__name__,
+                    'split': item.get('split', ''),
+                    'template_filename': item.get('template_filename', ''),
+                    'question_family_index': item.get('question_family_index', ''),
+                    'question_hash': item.get('question_hash', ''),
+                    'image_index': item.get('image_index', ''),
+                }
+            )
+
+        data = pd.DataFrame(rows)
+        dump(data, str(data_path))
+        self.data_path = str(data_path)
+        return data
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        if self.meta_only:
+            tgt_path = toliststr(line['image_path'])
+        else:
+            tgt_path = self.dump_image(line)
+
+        prompt = (
+            f"Question: {line['question']}\n"
+            "Answer with only the final answer. Do not add explanation."
+        )
+        if isinstance(tgt_path, list):
+            msgs = [dict(type='image', value=p) for p in tgt_path]
+        else:
+            msgs = [dict(type='image', value=tgt_path)]
+        msgs.append(dict(type='text', value=prompt))
+        return msgs
+
+    @staticmethod
+    def _normalize_answer(value, answer_type=None):
+        text = _normalize_text(value)
+        text = re.sub(r'^(answer|final answer)\s*[:\-]\s*', '', text)
+        text = text.strip(' .')
+
+        if answer_type == 'bool':
+            if text in {'true', 'yes', 'y'}:
+                return 'true'
+            if text in {'false', 'no', 'n'}:
+                return 'false'
+        elif answer_type == 'int':
+            match = re.search(r'-?\d+', text)
+            if match:
+                return str(int(match.group(0)))
+
+        return text
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        data = load(eval_file).sort_values(by='index')
+        data['prediction'] = [str(x) for x in data['prediction']]
+        data['answer_type'] = [str(x) for x in data['answer_type']]
+        data['norm_answer'] = [
+            self._normalize_answer(ans, answer_type)
+            for ans, answer_type in zip(data['answer'], data['answer_type'])
+        ]
+        data['norm_prediction'] = [
+            self._normalize_answer(pred, answer_type)
+            for pred, answer_type in zip(data['prediction'], data['answer_type'])
+        ]
+        data['hit'] = data['norm_answer'] == data['norm_prediction']
+
+        summary = {
+            'overall_accuracy': float(data['hit'].mean()) * 100.0,
+            'num_samples': int(len(data)),
+        }
+        for template_name, group in data.groupby('template_filename'):
+            if template_name:
+                summary[f'{template_name}_accuracy'] = float(group['hit'].mean()) * 100.0
+
+        score_file = get_intermediate_file_path(eval_file, '_score', 'json')
+        acc_file = get_intermediate_file_path(eval_file, '_acc', 'csv')
+        dump(summary, score_file)
+        acc_df = pd.DataFrame(
+            [{'metric': key, 'value': value} for key, value in summary.items()]
+        )
+        dump(acc_df, acc_file)
+        return summary
+
+
+class TriBenchDataset(ImageBaseDataset):
+    TYPE = 'VQA'
+    DATASET_URL = {'TRI-Bench': ''}
+    DATASET_MD5 = {}
+
+    Q_KEYS = [
+        'side_type',
+        'angle_type',
+        'ab_over_ac',
+        'abs_b_minus_c_deg',
+        'max_over_min_side',
+        'angle_range_deg',
+    ]
+
+    PROMPT_TEXT = (
+        'The image shows triangle ABC whose vertices are the centres of three small coloured square '
+        'stickers: A=RED, B=YELLOW, C=BLUE.\n'
+        'A light-brown masking-tape square border surrounds the scene in the same plane as triangle ABC.\n'
+        'All questions refer to triangle ABC. Angles are in DEGREES. "angle ABC" denotes the interior angle at vertex B.\n'
+        'Round all numeric answers to EXACTLY 4 decimals.\n\n'
+        'Q1. Is triangle ABC equilateral, isosceles, or scalene?\n'
+        'Q2. Is triangle ABC acute, right, or obtuse?\n'
+        'Q3. In triangle ABC, by what factor is the length AB greater than length AC? (i.e., estimate AB / AC)\n'
+        'Q4. In triangle ABC, by how much do angles angle ABC and angle ACB differ? '
+        '(i.e., estimate |angle ABC - angle ACB| in degrees)\n'
+        'Q5. In triangle ABC, what is (longest side) / (shortest side)?\n'
+        'Q6. In triangle ABC, what is (largest interior angle - smallest interior angle) in degrees?\n\n'
+        'Return STRICT JSON ONLY (no prose, markdown, code fences, or extra keys).\n'
+        'Use EXACTLY these keys; numbers must have exactly 4 decimals:\n'
+        '- "side_type": one of "equilateral", "isosceles", "scalene"\n'
+        '- "angle_type": one of "acute", "right", "obtuse"\n'
+        '- "ab_over_ac": number with 4 decimals\n'
+        '- "abs_b_minus_c_deg": number with 4 decimals\n'
+        '- "max_over_min_side": number with 4 decimals\n'
+        '- "angle_range_deg": number with 4 decimals\n'
+        'Output only the JSON object with these six keys and the computed values for THIS image.'
+    )
+
+    def load_data(self, dataset):
+        data_root = Path(LMUDataRoot())
+        data_root.mkdir(parents=True, exist_ok=True)
+        data_path = data_root / f'{self.dataset_name}.tsv'
+        if data_path.exists():
+            self.data_path = str(data_path)
+            return load(str(data_path))
+
+        repo_path = Path(__file__).resolve().parents[2] / 'ref_repos' / 'Tri-Bench'
+        if not repo_path.exists():
+            raise FileNotFoundError(
+                f'Tri-Bench repo not found at {repo_path}. Please clone the official repo first.'
+            )
+
+        tri_3d = pd.read_csv(repo_path / 'data' / 'tri_bench_triangles_3d.csv')
+        px_2d = pd.read_csv(repo_path / 'data' / 'tri_bench_pixel_geometry_2d.csv')
+
+        tri_3d_gt = tri_3d[['img_original', 'camera_view', 'object_in_square'] + self.Q_KEYS].copy()
+        tri_3d_gt = tri_3d_gt.rename(columns={k: f'{k}_3d' for k in self.Q_KEYS})
+        px_2d_gt = px_2d[['img_original'] + self.Q_KEYS].copy()
+        px_2d_gt = px_2d_gt.rename(columns={k: f'{k}_2d' for k in self.Q_KEYS})
+        merged = tri_3d_gt.merge(px_2d_gt, on='img_original', how='left')
+
+        rows = []
+        for idx, row in merged.reset_index(drop=True).iterrows():
+            rows.append(
+                {
+                    'index': idx,
+                    'image_path': str(repo_path / 'images' / row['img_original']),
+                    'question': self.PROMPT_TEXT,
+                    'img_original': row['img_original'],
+                    'camera_view': row['camera_view'],
+                    'object_in_square': row['object_in_square'],
+                    **{f'{key}_3d': row[f'{key}_3d'] for key in self.Q_KEYS},
+                    **{f'{key}_2d': row[f'{key}_2d'] for key in self.Q_KEYS},
+                }
+            )
+
+        data = pd.DataFrame(rows)
+        dump(data, str(data_path))
+        self.data_path = str(data_path)
+        return data
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        if self.meta_only:
+            tgt_path = toliststr(line['image_path'])
+        else:
+            tgt_path = self.dump_image(line)
+
+        msgs = [dict(type='text', value=line['question'])]
+        if isinstance(tgt_path, list):
+            msgs = [dict(type='image', value=p) for p in tgt_path] + msgs
+        else:
+            msgs = [dict(type='image', value=tgt_path)] + msgs
+        return msgs
+
+    @staticmethod
+    def _extract_json(prediction):
+        prediction = str(prediction).strip()
+        prediction = re.sub(r'^```(?:json)?', '', prediction).strip()
+        prediction = re.sub(r'```$', '', prediction).strip()
+        match = re.search(r'\{.*\}', prediction, flags=re.S)
+        if match is not None:
+            prediction = match.group(0)
+
+        for loader in (json.loads, ast.literal_eval):
+            try:
+                parsed = loader(prediction)
+                if isinstance(parsed, dict):
+                    return parsed
+            except Exception:
+                continue
+        return {}
+
+    @staticmethod
+    def _categorical_score(y_true, y_pred):
+        yt = _normalize_text(y_true)
+        yp = _normalize_text(y_pred)
+        return float(yt == yp)
+
+    @staticmethod
+    def _ratio_score(y_true, y_pred):
+        try:
+            t = float(y_true)
+            p = float(y_pred)
+        except Exception:
+            return 0.0
+        if abs(t) <= 1e-8:
+            return 0.0
+        err = min(abs(p - t) / abs(t), 1.0)
+        return 1.0 - err
+
+    @staticmethod
+    def _angle_score(y_true, y_pred):
+        try:
+            t = float(y_true)
+            p = float(y_pred)
+        except Exception:
+            return 0.0
+        err = min(abs(p - t) / 180.0, 1.0)
+        return 1.0 - err
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        data = load(eval_file).sort_values(by='index').reset_index(drop=True)
+        parsed = [self._extract_json(pred) for pred in data['prediction']]
+        parsed_df = pd.DataFrame(parsed)
+        for key in self.Q_KEYS:
+            data[f'pred_{key}'] = parsed_df[key] if key in parsed_df else None
+
+        for key in self.Q_KEYS:
+            if key in {'side_type', 'angle_type'}:
+                scorer = self._categorical_score
+            elif key in {'ab_over_ac', 'max_over_min_side'}:
+                scorer = self._ratio_score
+            else:
+                scorer = self._angle_score
+
+            data[f'{key}_acc_3d'] = [
+                scorer(gt, pred) for gt, pred in zip(data[f'{key}_3d'], data[f'pred_{key}'])
+            ]
+            data[f'{key}_acc_2d'] = [
+                scorer(gt, pred) for gt, pred in zip(data[f'{key}_2d'], data[f'pred_{key}'])
+            ]
+
+        summary = {
+            'overall_3d_accuracy': float(
+                np.mean(data[[f'{key}_acc_3d' for key in self.Q_KEYS]].to_numpy())
+            ) * 100.0,
+            'overall_2d_accuracy': float(
+                np.mean(data[[f'{key}_acc_2d' for key in self.Q_KEYS]].to_numpy())
+            ) * 100.0,
+            'num_images': int(len(data)),
+        }
+        for key in self.Q_KEYS:
+            summary[f'{key}_3d_accuracy'] = float(data[f'{key}_acc_3d'].mean()) * 100.0
+            summary[f'{key}_2d_accuracy'] = float(data[f'{key}_acc_2d'].mean()) * 100.0
+
+        score_file = get_intermediate_file_path(eval_file, '_score', 'json')
+        acc_file = get_intermediate_file_path(eval_file, '_acc', 'csv')
+        dump(summary, score_file)
+        acc_df = pd.DataFrame(
+            [{'metric': key, 'value': value} for key, value in summary.items()]
+        )
+        dump(acc_df, acc_file)
+        return summary

--- a/vlmeval/dataset/omnispatialbench.py
+++ b/vlmeval/dataset/omnispatialbench.py
@@ -1,0 +1,293 @@
+import os
+import ast
+import string
+import pandas as pd
+
+from tqdm import tqdm
+from collections import OrderedDict
+from huggingface_hub import snapshot_download
+
+from .image_mcq import ImageMCQDataset
+from ..smp.file import load
+from ..smp.misc import toliststr, get_cache_path
+
+# Prompt template adapted from the official OmniSpatial codebase:
+# https://github.com/qizekun/OmniSpatial/tree/main
+RE_FORMAT = """
+End your answer with a separate line formatted exactly as:
+
+Answer: X
+where X ∈ {A, B, C, D}.
+"""
+
+
+DEFAULT_SYSTEM_PROMPT = """
+You are a spatial-reasoning assistant.
+
+Task
+-----
+You will receive
+1. **Image** - a single RGB frame depicting a scene.
+2. **Question** - a natural-language query about spatial relationships between objects in the image.
+3. **Options** - ≥2 answer candidates, each tagged by a capital letter (A, B, C, D…).
+
+Based on the image and question, provide your answer.
+Always ground your answer in the visual evidence; do not hallucinate unseen objects.
+If uncertain, pick the most plausible option—never refuse or reply “insufficient information.”
+"""
+
+
+ZERO_SHOT_COT_SYSTEM_PROMPT = """
+You are a spatial-reasoning assistant.
+
+Task
+-----
+You will receive
+1. **Image** - a single RGB frame depicting a scene.
+2. **Question** - a natural-language query about spatial relationships between objects in the image.
+3. **Options** - ≥2 answer candidates, each tagged by a capital letter (A, B, C, D…).
+
+Think step by step and provide the answer.
+Always ground your answer in the visual evidence; do not hallucinate unseen objects.
+If uncertain, pick the most plausible option—never refuse or reply “insufficient information.”
+"""
+
+
+MANUAL_COT_SYSTEM_PROMPT = """
+You are a spatial-reasoning assistant.
+
+Task
+-----
+You will receive
+1. **Image** - a single RGB frame depicting a scene.
+2. **Question** - a natural-language query about spatial relationships between objects in the image.
+3. **Options** - ≥2 answer candidates, each tagged by a capital letter (A, B, C, D…).
+
+Guidelines
+----------
+Please follow these steps to analyze the image and answer the question:
+1. First, carefully observe the image and identify all relevant objects and their spatial relationships.
+2. Next, break down the question into key components that need to be addressed.
+3. Think through the spatial reasoning step-by-step to arrive at your answer. It may be necessary to transfer perspective to better understand the scene.   # noqa: E501
+4. Finally, select the most appropriate option (A, B, C, or D) based on your analysis.
+
+Always ground your answer in the visual evidence; do not hallucinate unseen objects.
+If uncertain, pick the most plausible option—never refuse or reply “insufficient information.”
+"""
+
+
+class OmniSpatialBench(ImageMCQDataset):
+    """
+    OmniSpatial.
+
+    Reference:
+      OmniSpatial: Towards Comprehensive Spatial Reasoning Benchmark for Vision Language Models
+      https://arxiv.org/abs/2506.03135
+    """
+
+    TYPE = 'MCQ'
+
+    OMNI_TSV_URL = 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/OmniSpatialBench.tsv'
+    OMNI_TSV_MD5 = '5d0896fc57c452055b020cc309ed799b'
+
+    VARIANTS = [
+        'OmniSpatialBench',
+        'OmniSpatialBench_default',
+        'OmniSpatialBench_zeroshot_cot',
+        'OmniSpatialBench_manual_cot',
+    ]
+
+    DATASET_URL = {}
+    DATASET_MD5 = {}
+
+    for name in VARIANTS:
+        DATASET_URL[name] = OMNI_TSV_URL
+        DATASET_MD5[name] = OMNI_TSV_MD5
+
+    SYS_PROMPTS = {
+        'default': DEFAULT_SYSTEM_PROMPT,
+        'zeroshot_cot': ZERO_SHOT_COT_SYSTEM_PROMPT,
+        'manual_cot': MANUAL_COT_SYSTEM_PROMPT,
+    }
+
+    CATEGORY_TASK_ORDER = OrderedDict([
+        ('Dynamic_Reasoning', ['Manipulation', 'Motion_Analysis']),
+        ('Spatial_Interaction', ['Traffic_Analysis', 'Localization', 'Geospatial_Strategy']),
+        ('Complex_Logic', ['Pattern_Recognition', 'Geometric_Reasoning']),
+        ('Perspective_Taking', ['Egocentric', 'Allocentric', 'Hypothetical']),
+    ])
+
+    def __init__(self, dataset, skip_noimg=True):
+        super().__init__(dataset=dataset, skip_noimg=skip_noimg)
+        self.prompt_mode = self.parse_dataset_name(dataset)
+
+    def parse_dataset_name(self, name: str) -> str:
+        if not isinstance(name, str):
+            return ''
+
+        lower = name.lower()
+
+        for key in self.SYS_PROMPTS.keys():
+            if lower.endswith(f'_{key}'.lower()):
+                return key
+
+        return ''
+
+    def prepare_tsv(self, url, file_md5=None, repo_id='qizekun/OmniSpatial'):
+        data = super().prepare_tsv(url, file_md5)
+
+        SENTINEL_NAME = '.omnispatialbench_extracted'
+        cache_path = get_cache_path(repo_id)
+
+        if (cache_path and os.path.isdir(cache_path)
+                and os.path.isfile(os.path.join(cache_path, SENTINEL_NAME))):
+            dataset_path = cache_path
+        else:
+            def _write_sentinel(sentinel_path, text='ok'):
+                tmp = sentinel_path + '.tmp'
+                with open(tmp, 'w', encoding='utf-8') as f:
+                    f.write(text)
+                os.replace(tmp, sentinel_path)
+
+            def unzip_hf_zip(pth):
+                import zipfile
+
+                base_dir = pth
+                zip_files = [
+                    os.path.join(base_dir, f) for f in os.listdir(base_dir)
+                    if f.endswith('.zip')
+                ]
+                zip_files.sort()
+
+                for zip_file in tqdm(zip_files, desc='Unpacking Origin Data...'):
+                    with zipfile.ZipFile(zip_file, 'r') as zf:
+                        for info in zf.infolist():
+                            if info.is_dir():
+                                continue
+
+                            rel = os.path.normpath(info.filename).lstrip('/\\')
+                            dst = os.path.join(pth, rel)
+
+                            absp = os.path.abspath(pth)
+                            absd = os.path.abspath(dst)
+                            if not absd.startswith(absp + os.sep):
+                                raise RuntimeError(f'Unsafe path in zip: {info.filename}')
+
+                            os.makedirs(os.path.dirname(dst), exist_ok=True)
+                            with zf.open(info, 'r') as src, open(dst, 'wb') as out:
+                                out.write(src.read())
+
+                sentinel_path = os.path.join(pth, SENTINEL_NAME)
+                _write_sentinel(sentinel_path, text='done')
+                print('OmniSpatial data extracted to current directory with original layout.')
+
+            dataset_path = snapshot_download(
+                repo_id=repo_id,
+                repo_type='dataset',
+                revision='main',
+                allow_patterns=['OmniSpatial-test.zip'],
+            )
+
+            unzip_hf_zip(dataset_path)
+
+        # === Transfer rel path to abs path ===
+        if 'image_path' in data.columns:
+            def fix_one(x: str):
+                if not isinstance(x, str):
+                    return x
+                s = x.strip()
+                s = os.path.expanduser(os.path.expandvars(s))
+
+                if not dataset_path:
+                    return os.path.normpath(s)
+                return os.path.normpath(os.path.join(dataset_path, 'OmniSpatial-test', s.lstrip(r'\/')))
+
+            def to_abs(p):
+                if isinstance(p, list):
+                    return [fix_one(xx) for xx in p]
+                if isinstance(p, str) and p.strip().startswith('[') and p.strip().endswith(']'):
+                    try:
+                        lst = ast.literal_eval(p)
+                        if isinstance(lst, list):
+                            return [fix_one(xx) for xx in lst]
+                    except Exception:
+                        pass
+                return fix_one(p)
+
+            data['image_path'] = data['image_path'].map(to_abs)
+
+        return data
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        if self.meta_only:
+            tgt_path = toliststr(line['image_path'])
+        else:
+            tgt_path = self.dump_image(line)
+
+        question = line['question']
+        options = {
+            cand: line[cand]
+            for cand in string.ascii_uppercase
+            if cand in line and not pd.isna(line[cand])
+        }
+        option_text = ''
+        for key, item in options.items():
+            option_text += f'\n{key}. {item}'
+
+        # prompt format from OmniSpatial codebase
+        if self.prompt_mode in self.SYS_PROMPTS.keys():
+            system_prompt = self.SYS_PROMPTS[self.prompt_mode]
+            prompt = system_prompt + '\n' + RE_FORMAT + '\n\n' + question + option_text
+
+        # EASI also provides direct QA format
+        else:
+            prompt = question + option_text + '\nAnswer directly with the option letter from the given choices. '
+
+        msgs = []
+        if isinstance(tgt_path, list):
+            msgs.extend([dict(type='image', value=p) for p in tgt_path])
+        else:
+            msgs = [dict(type='image', value=tgt_path)]
+        msgs.append(dict(type='text', value=prompt))
+
+        return msgs
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        from .utils.spatial_bench.cal_scores import eval_mcq_score, build_mcq_score_fn
+
+        # Select MCQ scoring function (rule-based or LLM-based) according to judge_kwargs['model'].
+        score_fn = build_mcq_score_fn(**judge_kwargs)
+
+        raw = eval_mcq_score(
+            load_fn=load,
+            eval_file=eval_file,
+            score_fn=score_fn,
+            group_col=['task_type', 'sub_task_type'],
+            order={
+                'task_type': list(self.CATEGORY_TASK_ORDER.keys()),
+                'sub_task_type': sum(self.CATEGORY_TASK_ORDER.values(), []),
+            },
+            dataset_name=getattr(self, 'dataset_name', 'OmniSpatialBench'),
+        )
+
+        pretty = OrderedDict()
+        pretty['overall'] = raw['overall']
+
+        for cat, tasks in self.CATEGORY_TASK_ORDER.items():
+            for t in tasks:
+                k = f'task.{t}_accuracy'
+                if k in raw:
+                    pretty[f'{t}_accuracy'] = raw[k]
+            cat_key = f'{cat}_accuracy'
+            if cat_key in raw:
+                pretty[cat_key] = raw[cat_key]
+
+        keys_str = ', '.join(pretty.keys())
+        vals_str = ', '.join(f'{v:.3f}' for v in pretty.values())
+        pretty['tabulated_keys'] = keys_str
+        pretty['tabulated_results'] = vals_str
+
+        return pretty

--- a/vlmeval/dataset/sitebench.py
+++ b/vlmeval/dataset/sitebench.py
@@ -1,0 +1,448 @@
+import os
+import json
+import ast
+import string
+import numpy as np
+import pandas as pd
+import warnings
+
+from PIL import Image
+from tqdm import tqdm
+from collections import OrderedDict
+from huggingface_hub import snapshot_download
+
+from ..smp.misc import toliststr, get_cache_path, modelscope_flag_set
+from ..smp.file import LMUDataRoot, dump, load
+from .video_base import VideoBaseDataset
+from .image_mcq import ImageMCQDataset
+
+try:
+    import decord
+except ImportError:
+    decord = None
+
+
+class SiteBenchBase:
+    """
+    SITE-Bench.
+
+    Reference:
+      SITE: towards Spatial Intelligence Thorough Evaluation
+      https://arxiv.org/abs/2505.05456
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        self.repo_id = 'franky-veteran/SITE-Bench'
+        super().__init__(*args, **kwargs)
+
+    def _task_category(self):
+        return [
+            'counting & existence',
+            'object localization & positioning',
+            '3d information understanding',
+            'multi-view & cross-image reasoning',
+            'spatial relationship reasoning',
+            'movement prediction & navigation',
+        ]
+
+    def download_sitebench(self, repo_id='franky-veteran/SITE-Bench'):
+        cache_path = get_cache_path(repo_id)
+        SENTINEL_NAME = '.sitebench_extracted'
+
+        if (cache_path and os.path.isdir(cache_path)
+                and os.path.isfile(os.path.join(cache_path, SENTINEL_NAME))):
+            dataset_path = cache_path
+        else:
+            def _write_sentinel(sentinel_path, text='ok'):
+                tmp = sentinel_path + '.tmp'
+                with open(tmp, 'w', encoding='utf-8') as f:
+                    f.write(text)
+                os.replace(tmp, sentinel_path)
+
+            def unzip_hf_zip(pth):
+                import zipfile
+
+                base_dir = pth
+                zip_files = [
+                    os.path.join(base_dir, f) for f in os.listdir(base_dir)
+                    if f.endswith('.zip')
+                ]
+                zip_files.sort()
+
+                for zip_file in tqdm(zip_files, desc='Unpacking Origin Data...'):
+                    with zipfile.ZipFile(zip_file, 'r') as zf:
+                        for info in zf.infolist():
+                            if info.is_dir():
+                                continue
+
+                            rel = os.path.normpath(info.filename).lstrip('/\\')
+                            dst = os.path.join(pth, rel)
+
+                            absp = os.path.abspath(pth)
+                            absd = os.path.abspath(dst)
+                            if not absd.startswith(absp + os.sep):
+                                raise RuntimeError(f'Unsafe path in zip: {info.filename}')
+
+                            os.makedirs(os.path.dirname(dst), exist_ok=True)
+                            with zf.open(info, 'r') as src, open(dst, 'wb') as out:
+                                out.write(src.read())
+
+                sentinel_path = os.path.join(pth, SENTINEL_NAME)
+                _write_sentinel(sentinel_path, text='done')
+                print('SiteBench data extracted to current directory with original layout.')
+
+            if modelscope_flag_set():
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+
+            unzip_hf_zip(dataset_path)
+
+        return dataset_path
+
+    def evaluate(self, eval_file, **kwargs):
+        from .utils.spatial_bench.cal_scores import build_mcq_score_fn, compute_caa_score, attach_score_cache
+        from .utils.spatial_bench.tools.files import build_eval_paths, get_judge_tag_from_score_fn
+
+        score_fn = build_mcq_score_fn(**kwargs)  # Select MCQ scoring func according to judge_kwargs['model'].
+        judge_tag = get_judge_tag_from_score_fn(score_fn)
+
+        result_file, xlsx_path, acc_tsv_path = build_eval_paths(eval_file, judge_tag)
+
+        data = load(eval_file)
+        if 'index' in data.columns:
+            data = data.sort_values(by='index')
+        data['prediction'] = [str(x) for x in data['prediction']]
+
+        # compute per-sample hit (MCQ)
+        attach_score_cache(
+            score_fn=score_fn,
+            eval_file=eval_file,
+            judge_tag=judge_tag,
+            key_col='index',
+            sub_tag='mcq',
+        )
+        mcq_scored = score_fn(data.copy())
+
+        cat_order = self._task_category()
+
+        summary = OrderedDict()
+        overall_acc = float(mcq_scored['hit'].mean()) if len(mcq_scored) else 0.0
+        overall_caa = compute_caa_score(mcq_scored) if len(mcq_scored) else 0.0
+        summary['overall_accuracy'] = overall_acc * 100.0
+        summary['overall_caa'] = overall_caa * 100.0
+
+        # per-category
+        if 'category' in mcq_scored.columns:
+            for cat in cat_order:
+                sub = mcq_scored[mcq_scored['category'] == cat]
+                if len(sub):
+                    acc_cat = float(sub['hit'].mean())
+                    caa_cat = compute_caa_score(sub)
+                    summary[f'{cat}_accuracy'] = acc_cat * 100.0
+                    summary[f'{cat}_caa'] = caa_cat * 100.0
+
+        tab_keys = ', '.join(list(summary.keys()))
+        tab_vals = ', '.join([f'{v:.3f}' for v in summary.values()])
+        summary['tabulated_keys'] = tab_keys
+        summary['tabulated_results'] = tab_vals
+
+        try:
+            import pickle
+            with open(result_file, 'wb') as f:
+                pickle.dump({'mcq_scored': mcq_scored, 'summary': summary}, f)
+            print(f'[save] result saved to {result_file}')
+        except Exception as e:
+            warnings.warn(f'[save] failed to save result to {result_file}: {e}')
+
+        try:
+            prefer_front = [
+                'index', 'question_type', 'category',
+                'prediction', 'pred_extracted', 'answer', 'hit'
+            ]
+            merged = mcq_scored.copy()
+            ordered = (
+                [c for c in prefer_front if c in merged.columns]
+                + [c for c in merged.columns if c not in prefer_front]
+            )
+            merged = merged[ordered]
+
+            with pd.ExcelWriter(xlsx_path, engine='openpyxl') as writer:
+                merged.to_excel(writer, sheet_name='ALL', index=False)
+            print(f'[save] extract & matching saved to {xlsx_path}')
+        except Exception as e:
+            warnings.warn(f'[save] failed to save extract xlsx to {xlsx_path}: {e}')
+
+        try:
+            acc_df = pd.DataFrame(
+                [(k, v) for k, v in summary.items() if k not in ('tabulated_keys', 'tabulated_results')],
+                columns=['metric', 'value']
+            )
+
+            metric_order = ['overall_accuracy', 'overall_caa']
+            metric_order += [f'{c}_accuracy' for c in cat_order if f'{c}_accuracy' in acc_df['metric'].values]
+            metric_order += [f'{c}_caa' for c in cat_order if f'{c}_caa' in acc_df['metric'].values]
+
+            metric_order += [k for k in acc_df['metric'].tolist() if k not in metric_order]
+
+            acc_df = acc_df.set_index('metric').reindex(metric_order).reset_index()
+            acc_df = acc_df.dropna(subset=['value'])
+            acc_df.to_csv(acc_tsv_path, sep='\t', index=False)
+            print(f'[save] accuracy/CAA table saved to {acc_tsv_path}')
+        except Exception as e:
+            warnings.warn(f'[save] failed to save acc tsv to {acc_tsv_path}: {e}')
+
+        print(f'[{getattr(self, "dataset_name", "MCQ")}] summary: {summary}')
+        return summary
+
+
+class SiteBenchImage(SiteBenchBase, ImageMCQDataset):
+    TYPE = 'MCQ'
+
+    DATASET_URL = {
+        'SiteBenchImage': 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/SiteBenchImage.tsv'  # noqa: E501
+    }
+
+    DATASET_MD5 = {
+        'SiteBenchImage': '59a2ada248b743c1d7b2f89dd5afcdc3'
+    }
+
+    def prepare_tsv(self, url, file_md5=None):
+        data = super().prepare_tsv(url, file_md5)
+
+        dataset_path = self.download_sitebench(self.repo_id)
+
+        # === Transfer rel path to abs path ===
+        if 'image_path' in data.columns:
+            def fix_one(x: str):
+                if not isinstance(x, str):
+                    return x
+                s = x.strip()
+                s = os.path.expanduser(os.path.expandvars(s))
+
+                if not dataset_path:
+                    return os.path.normpath(s)
+                return os.path.normpath(os.path.join(dataset_path, s.lstrip(r'\/')))
+
+            def to_abs(p):
+                if isinstance(p, list):
+                    return [fix_one(xx) for xx in p]
+                if isinstance(p, str) and p.strip().startswith('[') and p.strip().endswith(']'):
+                    try:
+                        lst = ast.literal_eval(p)
+                        if isinstance(lst, list):
+                            return [fix_one(xx) for xx in lst]
+                    except Exception:
+                        pass
+                return fix_one(p)
+
+            data['image_path'] = data['image_path'].map(to_abs)
+
+        return data
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        if self.meta_only:
+            tgt_path = toliststr(line['image_path'])
+        else:
+            tgt_path = self.dump_image(line)
+
+        question = line['question']
+        options = line['options']
+
+        upper_letters = list(string.ascii_uppercase)
+
+        if isinstance(options, str):
+            try:
+                options = json.loads(options)
+            except Exception:
+                options = ast.literal_eval(options)
+
+        option_text = '\n'.join(
+            f'{upper_letters[i]}: {options[i]}'
+            for i in range(len(options))
+        )
+
+        prompt = ''
+        if '<image>' not in question and '<image>' not in option_text:
+            prompt = '<image>' * len(tgt_path) + '\n'
+
+        # prompt format aligned with SITE paper
+        prompt += 'Question: ' + question + '\n'
+        prompt += 'Options:\n' + option_text + '\n'
+        post_prompt = 'Give me the answer letter directly. The best answer is:'
+        prompt += post_prompt
+
+        msgs = self.build_msgs(tgt_path, prompt)
+        return msgs
+
+    @staticmethod
+    def build_msgs(tgt_path, prompt):
+        """
+        Interlaced text and pictures.
+        """
+        images = tgt_path if isinstance(tgt_path, list) else [tgt_path]
+
+        parts = prompt.split('<image>')
+        segs = []
+
+        for i, part in enumerate(parts):
+            part = part.strip()
+            if part:
+                segs.append(dict(type='text', value=part))
+            if (i != len(parts) - 1) and (i < len(images)):
+                segs.append(dict(type='image', value=images[i]))
+
+        return [s for s in segs if s['value']]
+
+
+class SiteBenchVideo(SiteBenchBase, VideoBaseDataset):
+
+    MD5 = ''
+
+    TYPE = 'Video-MCQ'
+    MODALITY = 'VIDEO'
+
+    LMUData_root = LMUDataRoot()
+    DATASET_URL = {
+        'SiteBenchVideo': 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/SiteBenchVideo.tsv'  # noqa: E501
+    }
+    DATASET_MD5 = {
+        'SiteBenchVideo': 'bb2ac531fa83cf8280b23c25d738922d'
+    }
+
+    def __init__(self, dataset='SiteBenchVideo', pack=False, nframe=0, fps=-1):
+        super().__init__(dataset=dataset, pack=pack, nframe=nframe, fps=fps)
+
+    @classmethod
+    def supported_datasets(cls):
+        return ['SiteBenchVideo']
+
+    def prepare_dataset(self, dataset_name='SiteBenchVideo'):
+        data = super().prepare_tsv(
+            self.DATASET_URL[self.dataset_name],
+            self.DATASET_MD5[self.dataset_name]
+        )
+
+        dataset_path = self.download_sitebench(self.repo_id)
+        self.dataset_path = dataset_path
+
+        # === Transfer rel path to abs path ===
+        if 'video_path' in data.columns:
+            def fix_one(x: str):
+                if not isinstance(x, str):
+                    return x
+                s = x.strip()
+                s = os.path.expanduser(os.path.expandvars(s))
+
+                if not dataset_path:
+                    return os.path.normpath(s)
+                return os.path.normpath(os.path.join(dataset_path, s.lstrip(r'\/')))
+
+            def to_abs(p):
+                if isinstance(p, list):
+                    return [fix_one(xx) for xx in p]
+                if isinstance(p, str) and p.strip().startswith('[') and p.strip().endswith(']'):
+                    try:
+                        lst = ast.literal_eval(p)
+                        if isinstance(lst, list):
+                            return [fix_one(xx) for xx in lst]
+                    except Exception:
+                        pass
+                return fix_one(p)
+
+            data['video'] = data['video_path'].map(to_abs)
+
+        new_data_path = os.path.join(self.LMUData_root, 'SiteBenchVideo_abs_path.tsv')
+        if not os.path.exists(new_data_path):
+            dump(data, new_data_path)
+
+        return dict(data_file=new_data_path, root=dataset_path)
+
+    def save_video_frames(self, video, video_llm=False):
+        if decord is None:
+            raise ImportError(
+                'SiteBenchVideo requires `decord` for frame extraction. '
+                'Please install decord or use image-only SITE evaluation.'
+            )
+        vid_path = video
+        rel_video_path = os.path.relpath(video, self.dataset_path)
+
+        vid = decord.VideoReader(vid_path)
+        video_nframes = len(vid)
+        video_fps = vid.get_avg_fps()
+        video_info = {
+            'fps': video_fps,
+            'n_frames': video_nframes,
+        }
+
+        if self.nframe > 0 and self.fps < 0:
+            indices = np.linspace(0, video_nframes - 1, self.nframe, dtype=int).tolist()
+            # Use os.path.relpath for robust relative path extraction
+            frame_paths = self.frame_paths(rel_video_path)
+
+        elif self.fps > 0:
+            total_duration = video_nframes / video_fps
+            required_frames = int(total_duration * self.fps)
+            step_size = video_fps / self.fps
+
+            indices = [int(i * step_size) for i in range(required_frames)]
+            frame_paths = self.frame_paths_fps(rel_video_path, len(indices))
+
+        missing = [
+            (idx, pth) for idx, pth in zip(indices, frame_paths)
+            if not os.path.exists(pth)
+        ]
+
+        if missing and not video_llm:
+            for frame_idx, pth in missing:
+                try:
+                    frame_data = vid[frame_idx].asnumpy()
+                    Image.fromarray(frame_data).save(pth)
+                except Exception as e:
+                    error_msg = f"Error saving frame {frame_idx} from {vid_path}: {str(e)}"
+                    print(error_msg)
+
+                    raise ValueError(error_msg) from e
+
+        return frame_paths, indices, video_info
+
+    def build_prompt(self, line, video_llm):
+        if isinstance(line, int):
+            assert line < len(self)
+            line = self.data.iloc[line]
+
+        question = line['question']
+        raw_options = ast.literal_eval(line['candidates'])
+
+        option_labels = list(string.ascii_uppercase)
+        assert len(raw_options) <= len(option_labels), 'Too many options, extend option_labels if needed'
+
+        options = [f'{label}: {opt}' for label, opt in zip(option_labels, raw_options)]
+        formatted_options = '\n'.join(options)
+
+        # video prompt from SITE paper
+        pre_prompt = (
+            'Select the best answer to the following multiple-choice question based on the video. '
+            'Respond with only the letter of the correct option.'
+        )
+        post_prompt = 'Give me the answer letter directly. The best answer is:'
+
+        question_text = 'Question: ' + question + '\n'
+        option_text = 'Options:\n' + formatted_options + '\n'
+
+        prompt = pre_prompt + '\n' + question_text + option_text + post_prompt
+
+        message = []
+        if video_llm:
+            message.append(dict(type='video', value=line['video']))
+        else:
+            frames, _, _ = self.save_video_frames(line['video'], video_llm)
+            for im in frames:
+                message.append(dict(type='image', value=im))
+
+        message.append(dict(type='text', value=prompt))
+        return message

--- a/vlmeval/dataset/spatialvizbench.py
+++ b/vlmeval/dataset/spatialvizbench.py
@@ -1,0 +1,146 @@
+import string
+import pandas as pd
+
+from collections import OrderedDict
+
+from .image_mcq import ImageMCQDataset
+from ..smp.file import load
+from ..smp.misc import toliststr
+
+
+class SpatialVizBench(ImageMCQDataset):
+    """
+    SpatialViz-Bench.
+
+    Reference:
+      SpatialViz-Bench: An MLLM Benchmark for Spatial Visualization
+      https://arxiv.org/abs/2507.07610
+    """
+
+    TYPE = 'MCQ'
+
+    SPATIALVIZ_TSV_URL = 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/SpatialVizBench.tsv'  # noqa: E501
+    SPATIALVIZ_TSV_MD5 = '5ed4cb6463bfed0a92e52ffc4e8b6257'
+
+    VARIANTS = ['SpatialVizBench', 'SpatialVizBench_CoT']
+
+    DATASET_URL = {}
+    DATASET_MD5 = {}
+
+    for name in VARIANTS:
+        DATASET_URL[name] = SPATIALVIZ_TSV_URL
+        DATASET_MD5[name] = SPATIALVIZ_TSV_MD5
+
+    _CATEGORY_TASK_ORDER = None
+
+    def __init__(self, dataset, skip_noimg=True):
+        super().__init__(dataset=dataset, skip_noimg=skip_noimg)
+
+        self._CATEGORY_TASK_ORDER = None
+        self.use_cot = self.parse_dataset_name(dataset)
+        print(f'Evaluate {dataset} with CoT = {self.use_cot}')
+
+    @staticmethod
+    def parse_dataset_name(name: str) -> bool:
+        if not isinstance(name, str):
+            return False
+
+        lower = name.lower()
+        return lower.endswith('_cot')
+
+    @classmethod
+    def category_task_order(cls) -> OrderedDict:
+        if cls._CATEGORY_TASK_ORDER is None:
+            cls._CATEGORY_TASK_ORDER = OrderedDict([
+                ('MentalRotation', ['2DRotation', '3DRotation', '3ViewProjection']),
+                ('MentalFolding', ['PaperFolding', 'CubeUnfolding', 'CubeReconstruction']),
+                ('VisualPenetration', ['CrossSection', 'CubeCounting', 'CubeAssembly']),
+                ('MentalAnimation', ['ArrowMoving', 'BlockMoving', 'MechanicalSystem']),
+            ])
+        return cls._CATEGORY_TASK_ORDER
+
+    def build_prompt(self, line):
+        if isinstance(line, int):
+            line = self.data.iloc[line]
+
+        if self.meta_only:
+            tgt_path = toliststr(line['image_path'])
+        else:
+            tgt_path = self.dump_image(line)
+
+        question = line['question']
+        options = {
+            cand: line[cand]
+            for cand in string.ascii_uppercase
+            if cand in line and not pd.isna(line[cand])
+        }
+
+        options_text = ''
+        for key, item in options.items():
+            options_text += f'{key}. {item}\n'
+
+        # prompt format follow SpatialViz paper
+        if not self.use_cot:
+            pre_prompt = (
+                'Answer with a single option letter (A, B, C, or D), enclosed within the <answer></answer> tag. '
+                'For example: <answer>A</answer>. Ensure that your output contains only the final answer, '
+                'without any intermediate reasoning or additional content.'
+            )
+        else:
+            pre_prompt = (
+                'You should first provide a reasoning process, '
+                'then provide a single option (A, B, C or D) as the final answer. '
+                'The reasoning process and the answer are enclosed within '
+                '<think></think> and <answer></answer> tags, respectively, '
+                'i.e., <think>reasoning process</think>, <answer>answer</answer>.'
+            )
+
+        prompt = pre_prompt + '\n' + 'Question:' + question + '\n' + options_text
+
+        msgs = []
+        if isinstance(tgt_path, list):
+            msgs.extend([dict(type='image', value=p) for p in tgt_path])
+        else:
+            msgs = [dict(type='image', value=tgt_path)]
+        msgs.append(dict(type='text', value=prompt))
+
+        return msgs
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        from .utils.spatial_bench.cal_scores import eval_mcq_score, build_mcq_score_fn
+
+        # Select MCQ scoring function (rule-based or LLM-based) according to judge_kwargs['model'].
+        score_fn = build_mcq_score_fn(**judge_kwargs)
+
+        category_task_order = self.category_task_order()
+        raw = eval_mcq_score(
+            load_fn=load,
+            eval_file=eval_file,
+            score_fn=score_fn,
+            group_col=['category', 'task'],
+            order={
+                'category': list(category_task_order.keys()),
+                'task': sum(category_task_order.values(), []),
+            },
+            dataset_name=getattr(self, 'dataset_name', 'SpatialVizBench'),
+        )
+
+        pretty = OrderedDict()
+        pretty['overall'] = raw['overall']
+
+        for cat, tasks in category_task_order.items():
+            for t in tasks:
+                raw_key = f'task.{t}_accuracy'
+                if raw_key in raw:
+                    pretty[f'{t}_accuracy'] = raw[raw_key]
+
+            cat_raw_key = f'category.{cat}_accuracy'
+            if cat_raw_key in raw:
+                pretty[f'{cat}_accuracy'] = raw[cat_raw_key]
+
+        keys_str = ', '.join(pretty.keys())
+        vals_str = ', '.join(f'{v:.3f}' for v in pretty.values())
+        pretty['tabulated_keys'] = keys_str
+        pretty['tabulated_results'] = vals_str
+
+        return pretty

--- a/vlmeval/dataset/utils/spatial_bench/__init__.py
+++ b/vlmeval/dataset/utils/spatial_bench/__init__.py
@@ -1,1 +1,0 @@
-"""Utilities for spatial benchmark scoring."""

--- a/vlmeval/dataset/utils/spatial_bench/cal_scores.py
+++ b/vlmeval/dataset/utils/spatial_bench/cal_scores.py
@@ -1,85 +1,544 @@
-from collections import OrderedDict
-
+import ast
+import math
+import numpy as np
 import pandas as pd
+import warnings
 
-from .matching_func import can_match_option
-from ....smp.file import dump, get_intermediate_file_path
+from collections import OrderedDict
+from typing import Dict, Any, List
+
+from .matching_func import can_match_na, can_match_option
+from .tools.files import get_judge_tag_from_score_fn, build_eval_paths
+from .llm_extract import parallel_llm_extract
+from ..judge_util import build_judge
+from ....smp.vlm import gpt_key_set
+from ....smp.file import get_intermediate_file_path
 
 
+def exact_match(pred: str, target: str) -> float:
+    pred = str(pred).strip().lower()
+    target = str(target).strip().lower()
+    return 1. if pred == target else 0.
+
+
+def abs_dist_norm(pred: float, target: float) -> float:
+    if target == 0.0:
+        return abs(pred - target)
+    else:
+        return abs((pred - target) / target)
+
+
+def mean_relative_accuracy(
+    pred: float,
+    target: float,
+    start: float = 0.5,
+    end: float = 0.95,
+    interval: float = 0.05,
+) -> float:
+    # TODO：check this, should be + 1, but in vsi code this is + 2
+    num_pts = int((end - start) / interval + 2)
+    conf_intervs = np.linspace(start, end, num_pts)
+    err = abs_dist_norm(pred, target)
+    ok = (err <= (1 - conf_intervs)).astype(float)
+    return float(ok.mean())
+
+
+def to_float(x):
+    try:
+        return float(x)
+    except Exception:
+        return None
+
+
+def _safe_len_candidates(val):
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return None
+    if isinstance(val, list):
+        return len(val)
+    if isinstance(val, str):
+        try:
+            parsed = ast.literal_eval(val)
+            if isinstance(parsed, list):
+                return len(parsed)
+        except Exception:
+            return None
+    return None
+
+
+def _ensure_options_count_row(row, default_choices=4):
+    n = None
+    if 'candidates' in row:
+        n = _safe_len_candidates(row['candidates'])
+    elif 'options' in row:
+        n = _safe_len_candidates(row['options'])
+    return n if (isinstance(n, int) and n > 0) else default_choices
+
+
+# ---------- Rule-based scoring ----------
 def compute_mcq_score(df: pd.DataFrame) -> pd.DataFrame:
-    preds_extracted = []
-    hits = []
+    preds_extracted, acc = [], []
+    for _, r in df.iterrows():
+        pred_raw = str(r['prediction'])
+        gt_raw = str(r['answer']).strip()
 
-    for _, row in df.iterrows():
-        pred_raw = str(row.get('prediction', ''))
-        gt_raw = str(row.get('answer', '')).strip()
         pred = can_match_option(pred_raw)
         gt = can_match_option(gt_raw)
+
         preds_extracted.append(pred)
-        hits.append(1.0 if pred and gt and pred == gt else 0.0)
+        acc.append(exact_match(pred, gt))
 
-    scored = df.copy()
-    scored['pred_extracted'] = preds_extracted
-    scored['hit'] = hits
-    return scored
-
-
-def build_mcq_score_fn(**judge_kwargs):
-    def score_fn(df: pd.DataFrame) -> pd.DataFrame:
-        return compute_mcq_score(df)
-
-    score_fn.judge_mode = 'rule'
-    score_fn.judge_model = judge_kwargs.get('model', 'extract_matching')
-    return score_fn
+    df = df.copy()
+    df['pred_extracted'] = preds_extracted
+    df['hit'] = acc
+    return df
 
 
-def _ordered_categories(scored: pd.DataFrame, group_col: str, order=None):
-    if group_col not in scored.columns:
-        return []
-    present = [cat for cat in scored[group_col].dropna().unique().tolist()]
-    if order is None:
-        return present
-    preferred = [cat for cat in order if cat in present]
-    remaining = [cat for cat in present if cat not in preferred]
-    return preferred + remaining
+def compute_na_score(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Compute Mean Relative Accuracy (MRA) for numerical-answer (NA) items,
+    following the VSI codebase.
+
+    Definition:
+        For prediction ŷ, ground-truth y, and confidence threshold θ,
+        the relative accuracy is 1[ |ŷ - y| / |y| < 1 - θ ].
+        MRA averages this relative accuracy over θ ∈ {0.50, 0.55, ..., 0.95}.
+
+    Reference:
+        Thinking in Space: How Multimodal Large Language Models See, Remember, and Recall Spaces. (https://arxiv.org/pdf/2412.14171)  # noqa: E501
+    """
+    preds_extracted, mra_scores = [], []
+
+    for _, r in df.iterrows():
+        pred_num = can_match_na(str(r['prediction']))
+        gt_num = to_float(r['answer'])
+
+        preds_extracted.append(pred_num)
+
+        if pred_num is None or gt_num is None or math.isnan(gt_num):
+            mra_scores.append(0.0)          # WORST_CASE
+        else:
+            mra_scores.append(mean_relative_accuracy(pred_num, gt_num, .5, .95, .05))
+
+    df = df.copy()
+    df['pred_extracted'] = preds_extracted
+    df['MRA:.5:.95:.05'] = mra_scores
+    return df
 
 
+def compute_caa_score(df_all: pd.DataFrame, default_choices: int = 4) -> float:
+    """
+    Compute Class-Adjusted Accuracy (CAA) for Multiple Choice Questions.
+
+    Definition:
+    For each item i with n_i options and correctness indicator X_i ∈ {0, 1},
+        CAA = (Σ_i X_i - Σ_i (1 / n_i)) / (N - Σ_i (1 / n_i))
+            - N   : total number of evaluated items.
+            - X_i : 1 if the prediction for item i is correct, otherwise 0.
+            - n_i : number of answer options for item i.
+
+    Reference:
+        SITE: Towards Spatial Intelligence Thorough Evaluation. (https://arxiv.org/pdf/2505.05456)
+
+    """
+    if len(df_all) == 0:
+        return 0.0
+    n_list = df_all.apply(lambda r: _ensure_options_count_row(r, default_choices), axis=1)
+    xi = df_all['hit'].astype(int)
+    N = len(df_all)
+    sum_Xi = xi.sum()
+    sum_1_ni = (1.0 / n_list).sum()
+    denom = N - sum_1_ni
+    return float((sum_Xi - sum_1_ni) / denom) if denom != 0 else 0.0
+
+
+# High-level evaluation core for MCQ-style datasets
 def eval_mcq_score(
     *,
     load_fn,
     eval_file: str,
     score_fn,
-    group_col='category',
-    order=None,
-    dataset_name='MCQ',
+    group_col: str | list[str] = 'category',
+    order: list[str] | dict[str, list[str]] | None = None,
+    dataset_name: str = 'MCQ',
+    return_scored: bool = False,
 ):
+    judge_tag = get_judge_tag_from_score_fn(score_fn)
+    result_file, xlsx_path, acc_tsv_path = build_eval_paths(eval_file, judge_tag)
+
+    # only effective for LLM-based score_fn; rule-based is no-op
+    attach_score_cache(
+        score_fn=score_fn,
+        eval_file=eval_file,
+        judge_tag=judge_tag,
+        key_col='index',
+    )
+
     data = load_fn(eval_file)
     if 'index' in data.columns:
         data = data.sort_values(by='index')
     data['prediction'] = [str(x) for x in data['prediction']]
 
-    scored = score_fn(data.copy())
+    mcq_scored = score_fn(data.copy())
 
-    detail_path = get_intermediate_file_path(eval_file, '_extract_matching', 'xlsx')
-    dump(scored, detail_path)
-
-    summary = OrderedDict()
-    summary['overall'] = float(scored['hit'].mean() * 100.0) if len(scored) else 0.0
-
+    # ---------- group_cols / order_map ----------
     if isinstance(group_col, str):
         group_cols = [group_col]
     else:
         group_cols = list(group_col)
 
-    for gc in group_cols:
-        categories = _ordered_categories(scored, gc, order if gc == group_cols[0] else None)
-        prefix = '' if len(group_cols) == 1 else f'{gc}.'
-        for category in categories:
-            subset = scored[scored[gc] == category]
-            if len(subset):
-                summary[f'{prefix}{category}_accuracy'] = float(subset['hit'].mean() * 100.0)
+    if isinstance(order, dict) or order is None:
+        order_map: dict[str, list[str]] = order or {}
+    else:
+        order_map = {group_cols[0]: order}
 
-    score_path = get_intermediate_file_path(eval_file, '_score', 'json')
-    dump(summary, score_path)
+    summary = OrderedDict()
+    overall_acc = float(mcq_scored['hit'].mean()) if len(mcq_scored) else 0.0
+    summary['overall'] = overall_acc * 100.0
+
+    # ---------- category && tasks ----------
+    for gc in group_cols:
+        if gc not in mcq_scored.columns:
+            continue
+
+        preferred = order_map.get(gc, []) or []
+        present = list(mcq_scored[gc].dropna().unique().tolist())
+        remain = [c for c in present if c not in preferred]
+        cat_order = preferred + remain
+
+        prefix = '' if len(group_cols) == 1 else f'{gc}.'
+
+        for cat in cat_order:
+            sub = mcq_scored[mcq_scored[gc] == cat]
+            if len(sub):
+                acc = float(sub['hit'].mean()) * 100.0
+                summary[f'{prefix}{cat}_accuracy'] = acc
+
+    tab_keys = ', '.join(list(summary.keys()))
+    tab_vals = ', '.join([f'{v:.3f}' for v in summary.values()])
+    summary['tabulated_keys'] = tab_keys
+    summary['tabulated_results'] = tab_vals
+
+    # ---------- pkl ----------
+    try:
+        import pickle
+        with open(result_file, 'wb') as f:
+            pickle.dump({'mcq_scored': mcq_scored, 'summary': summary}, f)
+        print(f'[save] result saved to {result_file}')
+    except Exception as e:
+        warnings.warn(f'[save] failed to save result to {result_file}: {e}')
+
+    # ---------- extract_matching.xlsx ----------
+    try:
+        prefer_front = [
+            'index', 'question_type',
+            group_cols[0] if group_cols else None,
+            'prediction', 'pred_extracted', 'answer', 'hit'
+        ]
+        prefer_front = [c for c in prefer_front if c is not None]
+
+        merged = mcq_scored.copy()
+        ordered_cols = [c for c in prefer_front if c in merged.columns] + \
+                       [c for c in merged.columns if c not in prefer_front]
+        merged = merged[ordered_cols]
+        with pd.ExcelWriter(xlsx_path, engine='openpyxl') as writer:
+            merged.to_excel(writer, sheet_name='ALL', index=False)
+        print(f'[save] extract & matching saved to {xlsx_path}')
+    except Exception as e:
+        warnings.warn(f'[save] failed to save extract xlsx to {xlsx_path}: {e}')
+
+    # ---------- acc.tsv ----------
+    try:
+        acc_df = pd.DataFrame(
+            [(k, v) for k, v in summary.items()
+             if k not in ('tabulated_keys', 'tabulated_results')],
+            columns=['metric', 'value']
+        )
+
+        metric_order = ['overall']
+
+        for gc in group_cols:
+            preferred = order_map.get(gc, []) or []
+            prefix = '' if len(group_cols) == 1 else f'{gc}.'
+            metric_order += [f'{prefix}{c}_accuracy' for c in preferred]
+
+        metric_order += [k for k in acc_df['metric'].tolist()
+                         if k not in metric_order]
+
+        acc_df = acc_df.set_index('metric').reindex(metric_order).dropna(subset=['value'])
+        wide = acc_df.T
+        wide.to_csv(acc_tsv_path, sep='\t', index=False, float_format='%.4f')
+
+        print(f'[save] accuracy table saved to {acc_tsv_path}')
+    except Exception as e:
+        warnings.warn(f'[save] failed to save acc tsv to {acc_tsv_path}: {e}')
+
     print(f'[{dataset_name}] summary: {summary}')
+    if return_scored:
+        return summary, mcq_scored
     return summary
+
+
+# ---------- LLM-based scoring ----------
+def compute_score_llm(
+    df: pd.DataFrame,
+    model,
+    *,
+    mode: str = 'mcq',
+    max_retry: int = 3,
+    nproc: int = 4,
+    **extra,
+) -> pd.DataFrame:
+    """
+    LLM-based MCQ/VQA scoring.
+
+    Args:
+        df: input dataframe (must contain at least question / prediction / answer).
+        model: judge model with .generate(prompt: str) -> str
+        mode: 'mcq' or 'vqa'
+        max_retry: max retry times per sample
+        nproc: number of worker threads for parallel judging
+        extra:
+            - cache_file: optional cache pkl path
+            - key_col: column name used as cache key (default: 'index')
+    """
+    cache_file: str | None = extra.get('cache_file', None)
+    key_col: str = extra.get('key_col', 'index')
+
+    df = df.copy()
+    grades, extracted_list = parallel_llm_extract(
+        df=df,
+        model=model,
+        mode=mode,
+        max_retry=max_retry,
+        nproc=nproc,
+        cache_file=cache_file,
+        key_col=key_col,
+    )
+
+    hits = [1 if g == 'A' else 0 for g in grades]
+
+    df['judge_grade'] = grades          # 'A' / 'B' / 'C'
+    df['pred_extracted'] = extracted_list
+    df['hit'] = hits
+    return df
+
+
+def compute_na_score_llm(
+    df: pd.DataFrame,
+    model,
+    *,
+    mode: str = 'vqa',
+    max_retry: int = 3,
+    nproc: int = 4,
+    **extra,
+) -> pd.DataFrame:
+    """
+    LLM-based NA scoring.
+
+    Workflow:
+      - Use the LLM to extract the final numeric answer (mode='vqa')
+      - Then compute MRA from extracted number and ground truth.
+    """
+
+    cache_file: str | None = extra.get('cache_file', None)
+    key_col: str = extra.get('key_col', 'index')
+
+    df = df.copy()
+    grades, extracted_list = parallel_llm_extract(
+        df=df,
+        model=model,
+        mode=mode,
+        max_retry=max_retry,
+        nproc=nproc,
+        cache_file=cache_file,
+        key_col=key_col,
+    )
+
+    pred_nums: list[float | None] = []
+    mra_list: list[float] = []
+
+    for grade, extracted, (_, row) in zip(
+        grades, extracted_list, df.iterrows()
+    ):
+        pred_num = to_float(extracted)
+        gt_num = to_float(row.get('answer', None))
+
+        if (
+            pred_num is None
+            or gt_num is None
+            or math.isnan(gt_num)
+            or grade == 'C'
+        ):
+            mra = 0.0
+        else:
+            mra = mean_relative_accuracy(pred_num, gt_num, 0.5, 0.95, 0.05)
+
+        pred_nums.append(pred_num)
+        mra_list.append(mra)
+
+    df['judge_grade'] = grades              # 'A' / 'B' / 'C'
+    df['pred_extracted'] = pred_nums        # float or None
+    df['MRA:.5:.95:.05'] = mra_list
+    return df
+
+
+# ---------- Factory func ----------
+def attach_score_cache(
+    score_fn,
+    eval_file: str,
+    judge_tag: str,
+    *,
+    key_col: str = 'index',
+    sub_tag: str | None = None,
+):
+    """
+    Attach a cache file to an LLM-based score_fn for resume.
+
+    cache_file naming convention:
+        <eval_file base>_{judge_tag}[_<sub_tag>]_judge.<ext>
+
+    This function is no-op if:
+        - score_fn is None
+        - score_fn.judge_mode != 'llm'
+        - score_fn does not have 'llm_cache' attribute
+    """
+    if score_fn is None:
+        return None
+
+    if getattr(score_fn, 'judge_mode', 'rule') != 'llm':
+        return None
+
+    llm_cache = getattr(score_fn, 'llm_cache', None)
+    if llm_cache is None:
+        return None
+
+    suffix_parts = [f'_{judge_tag}']
+    if sub_tag:
+        suffix_parts.append(f'_{sub_tag}')
+    suffix = ''.join(suffix_parts) + '_judge'
+
+    cache_file = get_intermediate_file_path(
+        eval_file,
+        suffix=suffix,
+        target_format='pkl',
+    )
+
+    llm_cache['file'] = cache_file
+    llm_cache['key_col'] = key_col
+    return cache_file
+
+
+def _build_llm_judge(judge_kwargs: dict, *, task_name: str):
+    """
+    Try to build an LLM judge from judge_kwargs.
+
+    Returns:
+        - model instance if everything is OK;
+        - None if API key is missing or the judge is not working.
+    """
+    if not gpt_key_set():
+        warnings.warn(
+            f'OPENAI_API_KEY is not set properly, fallback to rule-based {task_name} scoring.'
+        )
+        return None
+
+    model = build_judge(**judge_kwargs)
+    if (model is None) or (hasattr(model, "working") and not model.working()):
+        warnings.warn(
+            f'LLM judge is not working properly, fallback to rule-based {task_name} scoring.'
+        )
+        return None
+
+    return model
+
+
+def _build_score_fn(
+    *,
+    task_name: str,
+    judge_kwargs: dict,
+    rule_fn: callable,
+    llm_fn: callable,
+    mode: str | None = None,
+):
+    """
+    Generic factory to choose between rule-based scoring and LLM-based scoring.
+
+    Args:
+        task_name: for logging only, e.g. "MCQ" / "NA".
+        judge_kwargs: kwargs used to build the judge model.
+        rule_fn: rule-based scorer, signature: rule_fn(df) -> df.
+        llm_fn: LLM-based scorer, signature:
+            llm_fn(df, model, mode=..., max_retry=..., nproc=...) -> df
+        mode: if not None, passed as mode=mode to llm_fn (for MCQ).
+    """
+    model_name = judge_kwargs.get('model', None)
+
+    def _make_rule_score_fn() -> callable:
+        def score_fn(df: pd.DataFrame) -> pd.DataFrame:
+            return rule_fn(df)
+
+        score_fn.judge_mode = 'rule'
+        # for rule-based path, if model_name is None, we treat it as 'extract_matching'
+        score_fn.judge_model = model_name or 'extract_matching'
+        return score_fn
+
+    # 1. Rule-based path
+    if model_name is None or model_name in ('exact_matching', 'extract_matching'):
+        return _make_rule_score_fn()
+
+    # 2. Build LLM judge
+    model = _build_llm_judge(judge_kwargs, task_name=task_name)
+    if model is None:
+        return _make_rule_score_fn()
+
+    max_retry = judge_kwargs.get('retry', 3)
+    nproc = judge_kwargs.get('nproc', judge_kwargs.get('api_nproc', 1) or 1)
+
+    llm_cache = {
+        'file': None,
+        'key_col': 'index',
+    }
+
+    # 3. Wrap into df -> df scorer
+    def score_fn(df: pd.DataFrame) -> pd.DataFrame:
+        kwargs = dict(
+            df=df,
+            model=model,
+            mode=mode,
+            max_retry=max_retry,
+            nproc=nproc,
+            cache_file=llm_cache['file'],
+            key_col=llm_cache['key_col'],
+        )
+        return llm_fn(**kwargs)
+
+    score_fn.judge_mode = 'llm'
+    score_fn.judge_model = model_name
+    score_fn.llm_cache = llm_cache
+    return score_fn
+
+
+def build_mcq_score_fn(**judge_kwargs):
+    """
+    Build an MCQ scoring function based on judge_kwargs['model'].
+    """
+    return _build_score_fn(
+        task_name='MCQ',
+        judge_kwargs=judge_kwargs,
+        rule_fn=compute_mcq_score,
+        llm_fn=compute_score_llm,   # note: this is the generic LLM scorer
+        mode='mcq',
+    )
+
+
+def build_na_score_fn(**judge_kwargs):
+    """
+    Build an NA scoring function based on judge_kwargs['model'].
+    """
+    return _build_score_fn(
+        task_name='NA',
+        judge_kwargs=judge_kwargs,
+        rule_fn=compute_na_score,
+        llm_fn=compute_na_score_llm,
+        mode='vqa',
+    )

--- a/vlmeval/dataset/utils/spatial_bench/llm_extract.py
+++ b/vlmeval/dataset/utils/spatial_bench/llm_extract.py
@@ -1,0 +1,312 @@
+import re
+import os
+import pandas as pd
+
+from typing import Dict, Any, List
+
+from .tools.utils import build_choices
+from ....smp.log import get_logger
+from ....smp.file import load
+from ....utils.mp_util import track_progress_rich
+
+
+GENERIC_EXTRACT_JUDGE_PROMPT = (
+    "You are an expert grading assistant.\n"
+    "Your job has TWO tasks:\n"
+    "1) From the candidate's full response, EXTRACT the final answer in a concise, normalized form.\n"
+    "2) Compare this extracted answer with the STANDARD ANSWER and grade it as:\n"
+    "   - A: CORRECT\n"
+    "   - B: INCORRECT\n"
+    "   - C: INVALID\n"
+    "\n"
+    "Here are the detailed evaluation criteria:\n"
+
+    "1. ALWAYS refer to the given STANDARD ANSWER. You do NOT need to re-solve the question; the standard answer has "
+    "already been provided and is always correct. Your only job is to judge whether the candidate's final answer is "
+    "consistent with the standard answer according to the form of the question. THE STANDARD ANSWER IS ALWAYS CORRECT "
+    "AND THE QUESTION IS PERFECTLY VALID. NEVER QUESTION THEM.\n"
+
+    "2. ONLY compare the FINAL ANSWER — COMPLETELY IGNORE any potential errors or issues in the REASONING PROCESS. "
+    "Even if the reasoning is wrong, as long as the final answer matches the standard answer, grade it as CORRECT.\n"
+
+    "3. Answers may be expressed in different ways (e.g., mathematical expressions, textual descriptions). As long as "
+    "the meaning is the same as the standard answer, treat them as equivalent. If the standard answer does not specify "
+    "a unit but the candidate's answer includes a correct unit for the given value, consider it CORRECT.\n"
+
+    "4. Some answers may consist of multiple items, such as multiple-choice questions with multiple correct options, "
+    "multi-select questions, or multi-blank fill-in-the-blank questions. Regardless of the question type, the final "
+    "answer is considered CORRECT only if it matches the standard answer exactly at the level of all required items. "
+    "For multi-select or multi-blank questions, ALL parts must be answered correctly and match the standard answer "
+    "exactly to be deemed CORRECT.\n"
+
+    "5. If the candidate's answer is wrapped in LaTeX-style markers like \\boxed{{...}}, IGNORE the \\boxed and only "
+    "use the inner content as the candidate's final answer when comparing with the standard answer.\n"
+
+    "6. If the candidate's answer is INVALID — for example, incomplete (cut off mid-response), containing a large "
+    "amount of abnormal repetitive content, clearly irrelevant to the question, or explicitly refusing to answer due "
+    "to ethical concerns, lack of information, or other external factors — then you MUST grade it as C: INVALID.\n"
+
+    "7. This instruction applies to all problem types, including single-choice MCQ, multi-select MCQ, numeric "
+    "problems, short-answer questions, and general VQA-style questions. In all cases, only the FINAL ANSWER and its "
+    "consistency with the standard answer matter.\n"
+
+    "8. The question or options may contain image placeholders such as '<image>', '<image id=1>', or similar tokens. "
+    "You CANNOT see these images. Treat these placeholders as unknown content and DO NOT hallucinate or infer any "
+    "specific visual details from them. If the standard answer or candidate's answer refers to an option associated "
+    "with an image (e.g., 'choose A'), judge correctness only based on the stated answer, not by imagining the image.\n"
+
+    "\n"
+    "IMPORTANT – OUTPUT FORMAT:\n"
+    "• You MUST return EXACTLY ONE line in the following format:\n"
+    "  <GRADE>\\t<EXTRACTED_ANSWER>\n"
+    "  where <GRADE> is one of A, B, or C.\n"
+    "• <EXTRACTED_ANSWER> should be the final answer you extracted from the candidate's response, in a normalized, "
+    "concise form (e.g., a number, a letter option, or a short phrase).\n"
+    "• If you cannot extract any meaningful answer, or the response is INVALID, output:\n"
+    "  C\\tN/A\n"
+    "• Do NOT add any extra text, explanation, or additional lines.\n"
+    "\n"
+    "Now, judge the following question.\n"
+    "<Original Question Begin>\n"
+    "{question}\n"
+    "{options_block}"
+    "<Original Question End>\n"
+    "<Standard Answer Begin>\n"
+    "{gold_answer}\n"
+    "<Standard Answer End>\n"
+    "<Candidate's Answer Begin>\n"
+    "{llm_response}\n"
+    "<Candidate's Answer End>\n"
+    "Your output:"
+)
+
+
+def build_option_str(option_dict):
+    s = ''
+    for c, content in option_dict.items():
+        if not pd.isna(content):
+            s += f'{c}. {content}\n'
+    return s
+
+
+def call_llm_extract(
+    model,
+    max_retry: int,
+    question: str,
+    prediction: str,
+    gold_answer: str,
+    options_block: str = ''
+):
+    """
+    Generic LLM call + parsing helper.
+
+    Returns:
+        (grade, extracted_answer)
+          - grade: 'A' / 'B' / 'C'
+          - extracted_answer: the final answer extracted by the LLM as a string,
+            or 'N/A' if none can be extracted.
+    """
+    logger = get_logger('LLM Extract')
+
+    prompt = GENERIC_EXTRACT_JUDGE_PROMPT.format(
+        question=question,
+        gold_answer=gold_answer,
+        llm_response=prediction,
+        options_block=options_block,
+    )
+
+    for _ in range(max_retry):
+        ans = model.generate(prompt).strip()
+        if 'Failed to obtain answer via API' in ans:
+            logger.warning('GPT API failed to answer. ')
+            continue
+
+        # Use only the first non-empty line to avoid verbose responses
+        line = ans.splitlines()[0].strip()
+
+        # Case 1. Grade + extracted
+        m = re.match(r'^\s*([ABC])\b(.*)$', line)
+        if m:
+            grade = m.group(1)
+
+            # Clean grade: uppercase and clamp to {A, B, C}
+            grade = str(grade).strip().upper()
+            if grade not in ('A', 'B', 'C'):
+                grade = 'C'
+
+            # Clean extracted answer
+            rest = m.group(2)  # get the raw remainder
+            rest = re.sub(r'^[\s\|,:]+', '', rest)  # strip leading whitespace + common separators
+            rest = re.sub(r'^(?:\\[tnr])+', '', rest)  # turn "\t", "\n", "\r" to spaces
+
+            extracted = rest.strip() or 'N/A'
+            return grade, extracted
+
+        # Case 2. Grade only
+        m2 = re.match(r'^\s*([ABC])\s*$', ans)
+        if m2:
+            grade = str(m2.group(1)).strip().upper()
+            if grade not in ('A', 'B', 'C'):
+                grade = 'C'
+            return grade, 'N/A'
+
+        logger.warning(f'Unparsable LLM output: {ans}')
+
+    logger.warning('LLM extract failed after max_retry, fallback to INVALID.')
+    return 'C', 'N/A'
+
+
+def extract_ans_by_llm(
+    model,
+    row: pd.Series,
+    mode: str = 'mcq',
+    max_retry: int = 3
+):
+    """
+    Generic LLM-based extraction + grading entry point.
+
+    Returns:
+        (grade, extracted_answer)
+        - grade in {'A', 'B', 'C'}
+        - extracted_answer: the final answer string extracted by the LLM
+    """
+    valid_mode = ['mcq', 'vqa']
+    assert mode in valid_mode, f'Extract llm func mode must be in {valid_mode}, but got {mode}!'
+
+    question = str(row.get('question', ''))
+    prediction = str(row.get('prediction', ''))
+    gold_raw = row.get('answer', '')
+
+    # Mode mcq
+    if mode == 'mcq':
+        # Build choices
+        choices = build_choices(row)
+        option_str = build_option_str(choices) if choices else ''
+
+        # Build options block for llm to know if there are options
+        options_block = ''
+        if option_str:
+            options_block = 'Options:\n' + option_str + '\n'
+        else:
+            options_block = ''
+
+        # Standard answer: prefer "letter + text" form if possible
+        answer_letter = str(gold_raw).strip().upper()
+        if choices and answer_letter in choices:
+            gold_answer = f'{answer_letter}. {choices[answer_letter]}'
+        else:
+            # Fallback: use raw answer field
+            gold_answer = str(gold_raw)
+
+    # Mode vqa
+    else:
+        options_block = ''
+        gold_answer = str(gold_raw)
+
+    grade, extracted = call_llm_extract(
+        model=model,
+        max_retry=max_retry,
+        question=question,
+        prediction=prediction,
+        gold_answer=gold_answer,
+        options_block=options_block,
+    )
+
+    return grade, extracted
+
+
+def parallel_llm_extract(
+    df: pd.DataFrame,
+    model,
+    *,
+    mode: str,
+    max_retry: int,
+    nproc: int,
+    cache_file: str | None = None,
+    key_col: str = 'index',
+) -> tuple[list, list]:
+    """
+    Run LLM-based answer extraction with optional cache.
+
+    Returns:
+        grades: list of 'A' / 'B' / 'C' (or None)
+        extracted_list: list of extracted answer strings (or None)
+    """
+    valid_mode = ['mcq', 'vqa']
+    assert mode in valid_mode, f'LLM extract mode must be in {valid_mode}, but got {mode}!'
+
+    df = df.copy()
+    rows: List[Dict[str, Any]] = list(df.to_dict(orient='records'))
+
+    def _one_sample(row: Dict[str, Any]):
+        """
+        Per-sample evaluation used by track_progress_rich.
+        Returns (grade, extracted), where grade ∈ {'A', 'B', 'C'}.
+        """
+        row = pd.Series(row)
+        grade, extracted = extract_ans_by_llm(
+            model=model,
+            row=row,
+            mode=mode,
+            max_retry=max_retry,
+        )
+        return grade, extracted
+
+    # ===== case 1: no cache, plain parallel run =====
+    if not cache_file:
+        tasks = [dict(row=r) for r in rows]
+        results = track_progress_rich(
+            func=_one_sample,
+            tasks=tasks,
+            nproc=nproc,
+        )
+        grades = [g for g, _ in results]
+        extracted_list = [e for _, e in results]
+        return grades, extracted_list
+
+    # ===== case 2: with cache, resume by key_col =====
+    # cache format: {key: (grade, extracted)}
+    cache: dict = {}
+    if os.path.exists(cache_file):
+        try:
+            cache = load(cache_file)
+            if not isinstance(cache, dict):
+                cache = {}
+        except Exception:
+            cache = {}
+
+    grades: list = [None] * len(rows)
+    extracted_list: list = [None] * len(rows)
+
+    tasks: list[dict] = []
+    keys: list = []
+    task_pos: list[int] = []
+
+    for i, row in enumerate(rows):
+        key = row.get(key_col, None)
+        if key is not None and key in cache:
+            val = cache[key]
+            if isinstance(val, (list, tuple)) and len(val) >= 2:
+                g, ex = val[0], val[1]
+            else:
+                g, ex = None, None
+            grades[i] = g
+            extracted_list[i] = ex
+        else:
+            tasks.append(dict(row=row))
+            keys.append(key)
+            task_pos.append(i)
+
+    if tasks:
+        results = track_progress_rich(
+            func=_one_sample,
+            tasks=tasks,
+            nproc=nproc,
+            save=cache_file,
+            keys=keys,
+        )
+        for pos, (g, ex) in zip(task_pos, results):
+            grades[pos] = g
+            extracted_list[pos] = ex
+
+    return grades, extracted_list

--- a/vlmeval/dataset/utils/spatial_bench/matching_func.py
+++ b/vlmeval/dataset/utils/spatial_bench/matching_func.py
@@ -1,50 +1,294 @@
 import re
+import ast
+
+from num2words import num2words
 
 
-def can_match_option(answer_text, choices=None, tail_lines=6, tail_window=800):
+# Zero-width characters (BOM, ZWSP, ZWNJ, ZWJ)
+ZW_RE = re.compile(
+    r'[\u200b\u200c\u200d\ufeff]'
+)
+
+# Generic numeric pattern: integer / float / scientific notation
+NUMERIC_PATTERN = r'[-+]?(?:\d*\.\d+|\d+)(?:[eE][-+]?\d+)?'
+
+_NUM_RE = re.compile(NUMERIC_PATTERN)
+
+# <answer>...</answer> block with a leading option letter (A–J)
+TAGGED_ANSWER_BLOCK = re.compile(
+    r'<\s*answer\b[^>]*>'  # <answer ...>
+    r'\s*'
+    r'([A-Ja-j])'
+    r'(?:\s*[\.．:：\)\]】、])?'  # Optional trailing punctuation, e.g. A. / A: / A) etc.
+    r'.*?'
+    r'<\s*/\s*answer\s*>',
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+# Numeric answer inside <answer>...</answer>
+TAGGED_NUMERIC_ANSWER = re.compile(
+    rf'<\s*answer\b[^>]*>'
+    rf'\s*'
+    rf'({NUMERIC_PATTERN})'
+    rf'(?:[^\d<][^<]*)?'
+    rf'<\s*/\s*answer\s*>',
+    flags=re.IGNORECASE | re.DOTALL,
+)
+
+
+# Matching func for mcq
+def can_match_option(
+    answer_text: str,
+    choices=None,
+    tail_lines: int = 6,
+    tail_window: int = 800
+):
+    """
+    Extract a single-choice option letter from free-form model output.
+
+    Return:
+        - 'A'..'F' (or restricted by `choices`) if a reliable match is found
+        - False otherwise
+
+    Procedure (1 → 7):
+      1) Dynamic letter set: build allowed letters (default A–F; shrink if `choices` given)
+      2) Block-level: <answer>...</answer> with leading letter (A–J allowed here)
+      3) Tail anchors: a letter immediately before </answer> or </think> within the tail window
+      4) Last-lines (after think-tail): scan last N lines after the last </think> (or <think>)
+         - full-line single letter (markdown/brackets allowed)
+         - labeled line start "A. ..."/"B) ..."
+         - unique inline uppercase token not part of words
+      5) Last-lines (global tail): same scan on the last N lines of the whole tail window
+      6) Phrase-style conclusion (tail window only), e.g. "final answer: B"
+         - capture is UPPERCASE only; use the last occurrence
+      7) Global fallback (strict): after removing enumeration lines, accept ONLY one
+         unique UPPERCASE standalone token across the entire text
+    """
+    # 1) Dynamic letter set
     if not isinstance(answer_text, str):
         return False
+    text = ZW_RE.sub('', answer_text.strip())
 
-    text = answer_text.strip()
-    letters = 'ABCDEFGHIJ'
     if choices:
-        allowed = {str(choice).strip().upper()[:1] for choice in choices if str(choice).strip()}
-        letters = ''.join(ch for ch in letters if ch in allowed) or 'ABCDEF'
+        letters_sorted = ''.join(sorted({str(c).strip().upper()[:1] for c in choices if str(c)}))
+        letters = ''.join([ch for ch in 'ABCDEFGHIJ' if ch in letters_sorted]) or 'ABCDEF'
     else:
         letters = 'ABCDEF'
 
-    block_pattern = re.compile(
-        rf'<\s*answer\b[^>]*>\s*([{letters}])(?:\s*[\.．:：\)\]】、])?.*?<\s*/\s*answer\s*>',
-        flags=re.IGNORECASE | re.DOTALL,
-    )
-    match = block_pattern.search(text)
-    if match:
-        return match.group(1).upper()
+    # 2) Block-level <answer>...</answer>
+    m_block = TAGGED_ANSWER_BLOCK.search(text)
+    if m_block:
+        return m_block.group(1).upper()
 
-    phrase_pattern = re.compile(
+    # 3) Tail anchors: before </answer> / </think>
+    tail_block = text[-tail_window:]
+    PAT_ANS = re.compile(
+        rf'(?<![A-Za-z])'          # Not preceded by a letter
+        rf'[\(\[\{{（【]?\s*'       # Optional left bracket + whitespace
+        rf'([{letters}])\s*'       # One option letter from `letters`
+        rf'[\)\]\}}）】]?\s*'       # Optional right bracket + whitespace
+        rf'</\s*answer\s*>',       # Closing </answer> tag
+        re.IGNORECASE,
+    )
+    PAT_THINK = re.compile(
+        rf'(?<![A-Za-z])'
+        rf'[\(\[\{{（【]?\s*'
+        rf'([{letters}])\s*'
+        rf'[\)\]\}}）】]?\s*'
+        rf'</\s*think\s*>',
+        re.IGNORECASE,
+    )
+    for pat in (PAT_ANS, PAT_THINK):
+        m = pat.search(tail_block)
+        if m:
+            return m.group(1).upper()
+
+    # Helpers for steps 4 & 5
+    # Punctuation treated as tight boundary after a token (EN + CN)
+    _PUNC_TIGHT = r"\.,:;!?\)\]】》」』，。；、：）】》」』"
+    # Lines that start with "option A:" / "选项 A:" style prefixes
+    OPTION_LINE_PREFIX = re.compile(
+        r'^(?:[*_>\-\s]*)(?:option|选项)\s+[A-J]\s*[:：]',
+        re.IGNORECASE,
+    )
+    # Lines whose content is a single option letter (with optional markdown/brackets)
+    MD_SINGLE = re.compile(
+        r'^\s*[*_`>（）\[\]【】\(\)]*\s*([A-Fa-f])\s*[*_`（）\[\]【】\(\)]*\s*$'
+    )
+    # Lines starting with "A. ...", "B) ...", etc.
+    LINE_START_LABELED = re.compile(
+        r'^\s*([A-F])\s*[\.．:：\)\]】、-]\s+',
+        re.IGNORECASE,
+    )
+    # Inline standalone uppercase token (not part of a word), e.g. the A in "answer A."
+    TOKEN_INLINE = re.compile(
+        rf'(?<![A-Za-z])'          # Not preceded by a letter
+        rf'[*_`（\[\{{\(]*\s*'     # optional prefix symbols + whitespace
+        rf'([A-F])\s*'             # Capture a single uppercase letter A–F
+        rf'[*_`）\]\}})]*'         # Optional suffix symbols
+        rf'(?=$|[\s{_PUNC_TIGHT}])'  # Followed by end, whitespace, or tight punctuation
+    )
+
+    def _pick_from_lines(lines):
+        for line in reversed([ln.strip() for ln in lines if ln.strip()]):
+            if OPTION_LINE_PREFIX.search(line):
+                continue
+            m = MD_SINGLE.fullmatch(line)
+            if m:
+                return m.group(1).upper()
+            m = LINE_START_LABELED.match(line)
+            if m:
+                return m.group(1).upper()
+            tokens = [t.upper() for t in TOKEN_INLINE.findall(line)]
+            if tokens:
+                uniq = sorted(set(tokens))
+                if len(uniq) == 1:
+                    return uniq[0]
+        return None
+
+    # 4) Last-lines after think-tail
+    if re.search(r'</\s*think\s*>', text, re.IGNORECASE):
+        tail_segment = text[list(re.finditer(r'</\s*think\s*>', text, re.IGNORECASE))[-1].end():].strip()
+    elif re.search(r'<\s*think\s*>', text, re.IGNORECASE):
+        tail_segment = text[list(re.finditer(r'<\s*think\s*>', text, re.IGNORECASE))[-1].end():].strip()
+    else:
+        tail_segment = text
+
+    pick = _pick_from_lines(tail_segment.splitlines()[-tail_lines:])
+    if pick:
+        return pick
+
+    # 5) Last-lines in global tail window
+    pick = _pick_from_lines(text[-tail_window:].splitlines()[-tail_lines:])
+    if pick:
+        return pick
+
+    # 6) Phrase-style conclusion in tail window (last match)
+    PHRASE_AFTER = re.compile(
+        # Prefix phrases like "final answer", "the answer is", "答案", "我选", etc.
         rf'(?i)(?:final\s*answer|the\s*answer\s*is|answer(?:\s*is)?|correct\s*answer|'
-        rf'答案|最终答案|结论|所以|因此|我选(?:择)?|选择|选)\s*[:：>＝=]?\s*'
-        rf'[\(\[\{{（【]?\s*([{letters}])\s*[\)\]\}}）】]?(?:\b|[.)、。])'
+        rf'答案|最终答案|结论|所以|因此|我选(?:择)?|选择|选)'
+        rf'\s*[:：>＝=]?\s*'         # optional separator (:, ：, >, ＝, =)
+        rf'[\(\[\{{（【]?\s*'        # optional left bracket
+        rf'([{letters}])'           # option letter from `letters`
+        rf'\s*[\)\]\}}）】]?'        # optional right bracket
+        rf'(?:\b|[.)、。])'          # followed by boundary / end punctuation
     )
-    match = phrase_pattern.search(text[-tail_window:])
-    if match:
-        return match.group(1).upper()
 
-    line_patterns = [
-        re.compile(rf'^\s*[*_`>（）\[\]【】\(\)]*\s*([{letters}])\s*[*_`（）\[\]【】\(\)]*\s*$'),
-        re.compile(rf'^\s*([{letters}])\s*[\.．:：\)\]】、-]\s+', flags=re.IGNORECASE),
-    ]
-    tail_segment = text[-tail_window:].splitlines()[-tail_lines:]
-    for line in reversed([line.strip() for line in tail_segment if line.strip()]):
-        for pattern in line_patterns:
-            match = pattern.match(line)
-            if match:
-                return match.group(1).upper()
+    m = PHRASE_AFTER.search(text)
+    if m:
+        return m.group(1).upper()
 
-    token_pattern = re.compile(rf'(?<![A-Za-z])([{letters}])(?![A-Za-z])')
-    tokens = [token.upper() for token in token_pattern.findall(text)]
-    unique_tokens = sorted(set(tokens))
-    if len(unique_tokens) == 1:
-        return unique_tokens[0]
+    # 7) Global fallback: uppercase-only & unique (skip enumerations)
+    cleaned_lines = []
+    for ln in text.splitlines():
+        if OPTION_LINE_PREFIX.search(ln):
+            continue
+        cleaned_lines.append(ln)
+    cleaned = "\n".join(cleaned_lines)
+
+    TOKEN_UPPER_GLOBAL = re.compile(
+        # Standalone option letter (not part of a word)
+        rf'(?<![A-Za-z])'          # left side not a letter
+        rf'[\(\[\{{（【]?\s*'       # optional left bracket + spaces
+        rf'([{letters}])\s*'       # one letter from `letters`
+        rf'[\)\]\}}）】]?'          # optional right bracket
+        rf'(?![A-Za-z])'           # right side not a letter
+    )
+    tokens = TOKEN_UPPER_GLOBAL.findall(cleaned)
+
+    uniq = sorted(set(tokens))
+    if len(uniq) == 1:
+        return uniq[0]
 
     return False
+
+
+def _after_think(text: str) -> str:
+    m_end = list(re.finditer(r'</\s*think\s*>', text, flags=re.IGNORECASE))
+    if m_end:
+        return text[m_end[-1].end():].strip()
+    m_start = list(re.finditer(r'<\s*think\s*>', text, flags=re.IGNORECASE))
+    if m_start:
+        return text[m_start[-1].end():].strip()
+    return text
+
+
+def _last_number(s: str):
+    nums = re.findall(_NUM_RE, s)
+    if nums:
+        return float(nums[-1])
+    return None
+
+
+def build_word2num(max_n: int = 99, lang: str = "en"):
+    mapping = {}
+    for i in range(0, max_n + 1):
+        word = num2words(i, lang=lang)
+        mapping[word] = i
+    return mapping
+
+
+WORD2NUM = build_word2num(20)
+WORD_NUMBER_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(w) for w in WORD2NUM.keys()) + r")\b",
+    flags=re.IGNORECASE,
+)
+
+
+def normalize_number_words(text: str) -> str:
+    """
+    Replace all recognizable English number phrases in `text`
+    with their Arabic numeral strings.
+    """
+    def _repl(m: re.Match) -> str:
+        key = m.group(1).lower()
+        val = WORD2NUM.get(key)
+        # Fallback: if not found in WORD2NUM, keep original text
+        return str(val) if val is not None else m.group(0)
+
+    return WORD_NUMBER_PATTERN.sub(_repl, text)
+
+
+# Matching func for NA
+def can_match_na(pred):
+    try:
+        if isinstance(pred, list):
+            candidates = [str(pred[0])] if pred else []
+        elif isinstance(pred, str) and pred.strip().startswith('[') and pred.strip().endswith(']'):
+            seq = ast.literal_eval(pred)  # safer than eval
+            candidates = [str(seq[0])] if isinstance(seq, list) and seq else [pred]
+        else:
+            candidates = [str(pred)]
+
+        for raw in candidates:
+            text = ZW_RE.sub('', raw.strip())
+            text = normalize_number_words(text)
+
+            # 1) <answer> ... </answer> numeric
+            m = TAGGED_NUMERIC_ANSWER.search(text)
+            if m:
+                try:
+                    return float(m.group(1))
+                except Exception:
+                    pass
+
+            # 2) after </think>: use *last* number in the tail
+            tail = _after_think(text)
+            v = _last_number(tail)
+            if v is not None:
+                return v
+
+            # 3) global fallback:
+            #    - if only one unique number -> that one
+            #    - else last number in full text
+            nums = re.findall(_NUM_RE, text)
+            if nums:
+                uniq = sorted(set(nums))
+                if len(uniq) == 1:
+                    return float(uniq[0])
+                return float(nums[-1])
+
+        return None
+    except Exception:
+        return None

--- a/vlmeval/dataset/utils/spatial_bench/tools/files.py
+++ b/vlmeval/dataset/utils/spatial_bench/tools/files.py
@@ -1,0 +1,57 @@
+from .....smp.file import get_intermediate_file_path
+
+
+def _judge_tag_from_mode_and_model(judge_mode: str | None, judge_model: str | None) -> str:
+    """
+    Map (judge_mode, judge_model) to a judge_tag string used in filenames.
+
+    Returns examples:
+        - 'extract_matching'
+        - 'llm_gpt-4o' / 'llm_matching'
+    """
+    if judge_mode == 'llm':
+        return f'llm_{judge_model}' if judge_model else 'llm_matching'
+    return 'extract_matching'
+
+
+def get_judge_tag_from_score_fn(score_fn) -> str:
+    """
+    Infer judge_tag from attributes attached to score_fn.
+
+    This relies on _build_score_fn setting:
+        score_fn.judge_mode
+        score_fn.judge_model
+    """
+    judge_mode = getattr(score_fn, 'judge_mode', 'rule')
+    judge_model = getattr(score_fn, 'judge_model', None)
+    return _judge_tag_from_mode_and_model(judge_mode, judge_model)
+
+
+def build_eval_paths(eval_file: str, judge_tag: str):
+    """
+    Build unified evaluation-related file paths from eval_file and judge_tag.
+
+    It returns:
+        - result_file: *_result.pkl
+        - xlsx_path  : *_{judge_tag}.xlsx
+        - acc_path   : *_acc.{EVAL_FORMAT or default csv}
+    """
+    result_file = get_intermediate_file_path(
+        eval_file,
+        suffix='_result',
+        target_format='pkl'
+    )
+
+    xlsx_path = get_intermediate_file_path(
+        eval_file,
+        suffix=f'_{judge_tag}',
+        target_format='xlsx'
+    )
+
+    acc_path = get_intermediate_file_path(
+        eval_file,
+        suffix=f'_{judge_tag}_acc'
+        # target_format=None -> resolved via suffix '_acc' -> get_eval_file_format()
+    )
+
+    return result_file, xlsx_path, acc_path

--- a/vlmeval/dataset/utils/spatial_bench/tools/utils.py
+++ b/vlmeval/dataset/utils/spatial_bench/tools/utils.py
@@ -1,0 +1,501 @@
+import re
+import ast
+import json
+import string
+import pandas as pd
+import numpy as np
+
+from .....smp.log import get_logger
+
+
+# ---------------------------------------------------------------------
+# From mcq items to build choices texts
+# ---------------------------------------------------------------------
+def _clean_text(x) -> str:
+    """Cast to str, collapse whitespace, strip."""
+    s = str(x)
+    s = re.sub(r'\s+', ' ', s)
+    return s.strip()
+
+
+def _nonempty(v) -> bool:
+    """Return True if v is not None/NaN/empty (after strip for scalars)."""
+    if v is None:
+        return False
+    if isinstance(v, float) and pd.isna(v):
+        return False
+    if isinstance(v, (list, tuple, set, dict)):
+        return len(v) > 0
+    return str(v).strip() != ""
+
+
+# Only whitespace + punctuation (no letters / digits / CJK)
+_ONLY_PUNCT_WS_RE = re.compile(r'^[\s\.\,\;\:\!\?\-\_/\\\|\(\)\[\]\{\}【】（）·・、—]+$')
+
+
+def _normalize_choice_body(raw) -> str:
+    """
+    Normalize choice text:
+      - None / NaN -> ''
+      - Collapse whitespace
+      - If only whitespace/punctuation -> ''
+      - Keep '<image>' etc. as-is
+    """
+    if raw is None or (isinstance(raw, float) and pd.isna(raw)):
+        return ''
+    txt = _clean_text(raw)
+    if not txt or _ONLY_PUNCT_WS_RE.fullmatch(txt):
+        return ''
+    return txt
+
+
+def _parse_candidates(val, max_letter: str = 'F'):
+    """
+    Parse 'options' / 'candidates' into a list of cleaned strings.
+    """
+    # 1) already a list
+    if isinstance(val, list):
+        return [_clean_text(x) for x in val]
+
+    # 2) string cases
+    if isinstance(val, str):
+        s = val.strip()
+        if not s:
+            return None
+
+        # 2a) try stringified Python list
+        try:
+            parsed = ast.literal_eval(s)
+            if isinstance(parsed, list):
+                return [_clean_text(x) for x in parsed]
+        except Exception:
+            # If parsing fails, fall back to extracting choices from the string.
+            pass
+
+        # 2b) fallback: treat as a mini "options block"
+        mapping = extract_choices_from_question(s, max_letter=max_letter)
+        if mapping:
+            out = []
+            for ch in string.ascii_uppercase:
+                if ch in mapping:
+                    out.append(_clean_text(mapping[ch]))
+                else:
+                    if ch == 'A':
+                        continue
+                    break
+            return out or None
+
+        return None
+
+    # 3) other types -> not supported
+    return None
+
+
+def _letters_upto(max_letter: str = 'F', n: int | None = None):
+    """
+    Letter set helper.
+
+    If n is given and > 0: ['A', ..., up to n].
+    Else: ['A', ..., max_letter].
+    """
+    max_letter = max_letter.upper()
+    all_letters = list(string.ascii_uppercase)
+    if n is not None and isinstance(n, int) and n > 0:
+        return all_letters[:min(n, 26)]
+    end_idx = all_letters.index(max_letter) + 1
+    return all_letters[:end_idx]
+
+
+# Extract choices from explicit columns (A/B/C/...)
+def _extract_from_columns(item, letter_set=('A', 'B', 'C', 'D', 'E', 'F')):
+    """
+    Read choices from columns A–F (or extended):
+
+      - column exists & nonempty -> normalized text
+      - column exists & empty    -> ''
+      - column missing           -> no key
+    """
+    return {
+        ch: (_normalize_choice_body(item[ch]) if _nonempty(item[ch]) else '')
+        for ch in letter_set
+        if ch in item
+    }
+
+
+# Extract choices from question text
+def _slice_by_markers(text: str, markers):
+    """
+    Given label markers (letter, end_idx, start_idx), slice text into segments:
+
+      [end_i : start_{i+1})  as body for letter_i,
+      last marker goes to end of text.
+    """
+    out = {}
+    markers = sorted(markers, key=lambda x: x[2])
+    for i, (ch, end_label, start_pos) in enumerate(markers):
+        next_start = markers[i + 1][2] if i + 1 < len(markers) else len(text)
+        raw = text[end_label:next_start]
+        out[ch] = _normalize_choice_body(raw)
+    return out
+
+
+def _contiguous_prefix_len(keys_iterable):
+    """
+    Count how many letters we have consecutively from 'A'.
+
+    {'A','B','C'} -> 3
+    {'B','C'}     -> 0
+    {'A','C'}     -> 1
+    """
+    s = {k.upper() for k in keys_iterable}
+    k = 0
+    for ch in string.ascii_uppercase:
+        if ch in s:
+            k += 1
+        else:
+            break
+    return k
+
+
+def extract_choices_from_question(q: str, max_letter: str = 'F') -> dict:
+    """
+    Heuristically parse choices from question text.
+
+    Tries:
+      - Line-based labels (each option starts a line)
+      - Inline labels ("A. xxx B. yyy C. zzz")
+
+    Returns: {'A': '...', 'B': '...', ...} or {}.
+    """
+    if not isinstance(q, str) or not q.strip():
+        return {}
+    text = q
+
+    # Drop preamble before "Options:" / "选项:"
+    m = re.search(r'(?i)(options?|选项)\s*[:：]?', text)
+    if m:
+        text = text[m.end():]
+
+    letters = ''.join(_letters_upto(max_letter))
+
+    # ---------------- Line-based: e.g. each option on its own line ----------------
+    LINE_LABEL = re.compile(
+        rf'(?mi)^[ \t]*'
+        rf'(?:[*_`>•·\-]+\s*)?'
+        rf'(?:[\(\[\{{（【]\s*)?'
+        rf'([{letters}])'                  # A / B / ...
+        rf'(?:\s*[\)\]\}}）】])?'
+        rf'\s*[\.．:：\)\]】、-]\s*'        # A. / A) / A: ...
+    )
+
+    from_lines: dict[str, str] = {}
+
+    for m in LINE_LABEL.finditer(text):
+        ch = m.group(1).upper()
+
+        line_end = text.find('\n', m.end())
+        if line_end == -1:
+            line_end = len(text)
+        raw = text[m.end():line_end]
+        body = _normalize_choice_body(raw)
+        from_lines[ch] = body
+
+    # ---------------- Inline: e.g. "A. foo  B. bar  C. baz" ----------------
+    INLINE_LABEL = re.compile(
+        rf'(?<![A-Za-z0-9])'
+        rf'([{letters}])'
+        rf'\s*[\.．:：\)\]】、-]\s*'
+        rf'(?![A-Za-z0-9])'
+    )
+    inline_markers = [(m.group(1).upper(), m.end(), m.start())
+                      for m in INLINE_LABEL.finditer(text)]
+    from_inline = _slice_by_markers(text, inline_markers) if inline_markers else {}
+
+    # Pick better candidate
+    ls_k = _contiguous_prefix_len(from_lines.keys())
+    il_k = _contiguous_prefix_len(from_inline.keys())
+
+    if ls_k > il_k:
+        chosen = from_lines
+    elif il_k > ls_k:
+        chosen = from_inline
+    else:
+        if len(from_lines) > len(from_inline):
+            chosen = from_lines
+        elif len(from_inline) > len(from_lines):
+            chosen = from_inline
+        else:
+            chosen = from_lines or from_inline
+
+    return chosen
+
+
+# Top-level: build_choices
+def build_choices(item: dict, max_letter: str = 'F') -> dict:
+    """
+    Build a choice dict for one item (row-like mapping).
+
+    Priority:
+      1) 'options' / 'candidates' (options > candidates)
+      2) Columns A..max_letter
+      3) Parse from question text
+      4) Fallback: {}
+    """
+    # 1) options / candidates
+    seq = None
+    for key in ('options', 'candidates'):
+        if key in item:
+            parsed = _parse_candidates(item[key])
+            if parsed:
+                seq = parsed
+                break
+
+    if seq:
+        letters = _letters_upto(n=len(seq))
+        return {ch: (seq[i] if i < len(seq) else '') for i, ch in enumerate(letters)}
+
+    # 2) A–F (or extended) columns
+    letters = _letters_upto(max_letter=max_letter)
+    from_cols = _extract_from_columns(item, letter_set=letters)
+    if from_cols:
+        return from_cols
+
+    # 3) From question text
+    q = item.get('question')
+    if isinstance(q, str):
+        from_q = extract_choices_from_question(q, max_letter=max_letter)
+        if from_q:
+            return from_q
+
+    # 4) Nothing found
+    return {}
+
+
+# ---------------------------------------------------------------------
+# From spatial items to parse 2d points
+# ---------------------------------------------------------------------
+class Point2DParser:
+    """
+    Generic 2D point parser.
+
+    - Parse model outputs into a set of (x, y) coordinates.
+    - Support JSON / Python literals and text patterns.
+    - First use _json2pts, then fall back to _text2pts.
+    """
+
+    _has_logged_hint = False
+    logger = get_logger('Point2DParser')
+
+    @classmethod
+    def log_hint(cls, task_name: str | None = None):
+        if cls._has_logged_hint:
+            return
+
+        prefix = f'[{task_name}]' if task_name else '[Point2DParser]'
+        msg = (
+            f'{prefix} Using default Point2DParser:\n'
+            '  - expects JSON / Python literal with "point_2d",\n'
+            '    where coordinates may be:\n'
+            '      * pixels (0 ~ W/H),\n'
+            '      * [0, 1] normalized,\n'
+            '      * [0, 1000] normalized (e.g., Qwen3-VL style);\n'
+            '  - falls back to "(x, y)" or "(x0, y0, x1, y1)" patterns in free text.\n'
+            'Use parse(..., output="pixel") for pixel coords (default), or\n'
+            'parse(..., output="norm") for [0, 1] normalized coords.\n'
+        )
+        cls.logger.info(msg)
+        cls._has_logged_hint = True
+
+    @classmethod
+    def parse(cls, text: str, width: int, height: int, output: str = 'pixel') -> np.ndarray:
+        """
+        Main entry.
+
+        Args:
+            text: raw model output.
+            width, height: image size.
+            output: 'pixel' for pixel coords, 'norm' for [0, 1] normalized coords.
+
+        Returns:
+            np.ndarray[N, 2]
+        """
+        if output not in ('pixel', 'norm'):
+            raise ValueError(f'Point2DParser.parse: unsupported output={output}')
+
+        pts = cls._json2pts(text, width, height, output=output)
+        if pts is not None:
+            return pts
+        return cls._text2pts(text, width, height, output=output)
+
+    @classmethod
+    def _json2pts(
+        cls,
+        text: str,
+        width: int = 640,
+        height: int = 480,
+        output: str = 'pixel'
+    ) -> np.ndarray | None:
+        """
+        Parse JSON/Python literals like:
+        [
+            {"point_2d": [x, y], "label": "..."},
+            ...
+        ]
+
+        point_2d / point can be:
+          - [0, 1] normalized
+          - [0, 1000] normalized
+          - pixels
+        """
+        s = cls._strip_md_fence(text).strip()
+
+        obj = None
+        try:
+            obj = json.loads(s)
+        except Exception:
+            pass
+
+        if obj is None:
+            try:
+                obj = ast.literal_eval(s)
+            except Exception:
+                return None
+
+        if isinstance(obj, dict):
+            obj = [obj]
+        if not isinstance(obj, list):
+            return None
+
+        pts_norm = []  # Store uniformly as 0~1 coordinates
+        w = float(width) if width else 1.0
+        h = float(height) if height else 1.0
+
+        for item in obj:
+            if not isinstance(item, dict):
+                continue
+            pt = item.get('point_2d') or item.get('point')
+            if not (isinstance(pt, (list, tuple)) and len(pt) == 2):
+                continue
+
+            x, y = pt
+            try:
+                x = float(x)
+                y = float(y)
+            except Exception:
+                continue
+
+            max_abs = max(abs(x), abs(y))
+
+            # map to [0,1]
+            if 0.0 <= max_abs <= 1.5:
+                x_norm, y_norm = x, y
+            elif 0.0 <= max_abs <= 1000.0:
+                x_norm = x / 1000.0
+                y_norm = y / 1000.0
+            else:
+                # assume pixels
+                x_norm = x / w
+                y_norm = y / h
+
+            pts_norm.append((x_norm, y_norm))
+
+        if not pts_norm:
+            return None
+
+        pts_norm = np.array(pts_norm, dtype=float)
+
+        if output == 'norm':
+            return pts_norm
+
+        # output == 'pixel'
+        x_pix = np.clip(pts_norm[:, 0] * w, 0, w - 1)
+        y_pix = np.clip(pts_norm[:, 1] * h, 0, h - 1)
+        pts_pix = np.stack([x_pix, y_pix], axis=1).round().astype(int)
+        return pts_pix
+
+    @staticmethod
+    def _text2pts(
+        text: str,
+        width: int = 640,
+        height: int = 480,
+        output: str = 'pixel'
+    ) -> np.ndarray:
+        """
+        Parse free-text patterns:
+            (x, y) or (x0, y0, x1, y1)
+        """
+        pattern = r'\(([-+]?\d+\.?\d*(?:,\s*[-+]?\d+\.?\d*)*?)\)'
+        matches = re.findall(pattern, text)
+        pts_norm = []
+        w = float(width) if width else 1.0
+        h = float(height) if height else 1.0
+
+        for match in matches:
+            nums = [float(num) for num in match.split(',')]
+            max_abs = max(abs(v) for v in nums)
+            is_norm = (0.0 <= max_abs <= 1.5)
+
+            if len(nums) == 2:
+                x, y = nums
+                if is_norm:
+                    x_norm, y_norm = x, y
+                else:
+                    x_norm = x / w
+                    y_norm = y / h
+                pts_norm.append((x_norm, y_norm))
+
+            elif len(nums) == 4:
+                x0, y0, x1, y1 = nums
+                if is_norm:
+                    x0 *= w
+                    y0 *= h
+                    x1 *= w
+                    y1 *= h
+
+                x0, y0, x1, y1 = map(float, (x0, y0, x1, y1))
+                if x1 < x0:
+                    x0, x1 = x1, x0
+                if y1 < y0:
+                    y0, y1 = y1, y0
+
+                x0_i, y0_i, x1_i, y1_i = map(int, map(round, (x0, y0, x1, y1)))
+                h_box = max(0, y1_i - y0_i)
+                w_box = max(0, x1_i - x0_i)
+                if h_box > 0 and w_box > 0:
+                    yy, xx = np.where(np.ones((h_box, w_box), dtype=np.uint8))
+                    x_pix = xx + x0_i
+                    y_pix = yy + y0_i
+                    x_norm = x_pix / w
+                    y_norm = y_pix / h
+                    pts_norm.extend(zip(x_norm, y_norm))
+
+        if not pts_norm:
+            return np.empty((0, 2), dtype=float if output == 'norm' else int)
+
+        pts_norm = np.array(pts_norm, dtype=float)
+
+        if output == 'norm':
+            return pts_norm
+
+        # output == 'pixel'
+        x_pix = np.clip(pts_norm[:, 0] * w, 0, w - 1)
+        y_pix = np.clip(pts_norm[:, 1] * h, 0, h - 1)
+        pts_pix = np.stack([x_pix, y_pix], axis=1).round().astype(int)
+        return pts_pix
+
+    @staticmethod
+    def _strip_md_fence(text: str) -> str:
+        s = text.strip()
+        if not s.startswith('```'):
+            return s
+
+        first_nl = s.find('\n')
+        if first_nl != -1:
+            inner = s[first_nl + 1:]
+        else:
+            inner = s.lstrip('`')
+
+        inner = inner.strip()
+        if inner.endswith('```'):
+            inner = inner[:-3]
+        return inner.strip()

--- a/vlmeval/dataset/video_dataset_config.py
+++ b/vlmeval/dataset/video_dataset_config.py
@@ -206,6 +206,12 @@ dream_1k_dataset = {
     'DREAM-1K_0.5fps': partial(DREAM, dataset='DREAM-1K', fps=0.5),
 }
 
+sitebenchvideo_dataset = {
+    'SiteBenchVideo_64frame': partial(SiteBenchVideo, dataset='SiteBenchVideo', nframe=64),
+    'SiteBenchVideo_32frame': partial(SiteBenchVideo, dataset='SiteBenchVideo', nframe=32),
+    'SiteBenchVideo_1fps': partial(SiteBenchVideo, dataset='SiteBenchVideo', fps=1.0),
+}
+
 supported_video_datasets = {}
 
 dataset_groups = [
@@ -213,6 +219,7 @@ dataset_groups = [
     mlvu_dataset, tempcompass_dataset, cgbench_dataset, worldsense_dataset, tamperbench_dataset,
     megabench_dataset, qbench_video_dataset, moviechat1k_dataset, vdc_dataset, video_holmes_dataset, vcrbench_dataset,
     cg_av_counting_dataset, video_mmlu_dataset, egoexobench_dataset, dream_1k_dataset, video_tt_dataset,
+    sitebenchvideo_dataset,
     vsibench_dataset
 ]
 

--- a/vlmeval/dataset/viewspatialbench.py
+++ b/vlmeval/dataset/viewspatialbench.py
@@ -1,0 +1,160 @@
+import os
+import ast
+
+from tqdm import tqdm
+from huggingface_hub import snapshot_download
+
+from ..smp.file import load
+from ..smp.misc import toliststr, get_cache_path, modelscope_flag_set
+from .image_mcq import ImageMCQDataset
+
+
+class ViewSpatialBench(ImageMCQDataset):
+    """
+    ViewSpatial-Bench.
+
+    Reference:
+      ViewSpatial-Bench: Evaluating Multi-perspective Spatial Localization in Vision-Language Models
+      https://arxiv.org/abs/2505.21500
+    """
+
+    TYPE = 'MCQ'
+
+    DATASET_URL = {
+        'ViewSpatialBench': 'https://huggingface.co/datasets/lmms-lab-si/EASI-Leaderboard-Data/resolve/main/ViewSpatialBench.tsv'  # noqa: E501
+    }
+    DATASET_MD5 = {
+        'ViewSpatialBench': 'c1c0c1522c5b8f5d72b3abad6af105cd'
+    }
+
+    def _task_category(self):
+        return [
+            'Camera perspective - Relative Direction',
+            'Camera perspective - Object View Orientation',
+            'Person perspective - Object View Orientation',
+            'Person perspective - Relative Direction',
+            'Person perspective - Scene Simulation Relative Direction'
+        ]
+
+    def prepare_tsv(self, url, file_md5=None, repo_id='lidingm/ViewSpatial-Bench'):
+        data = super().prepare_tsv(url, file_md5)
+
+        cache_path = get_cache_path(repo_id)
+        SENTINEL_NAME = ".viewspatialbench_extracted"
+        if (cache_path and os.path.isdir(cache_path)
+                and os.path.isfile(os.path.join(cache_path, SENTINEL_NAME))):
+            dataset_path = cache_path
+        else:
+            def _write_sentinel(sentinel_path, text="ok"):
+                tmp = sentinel_path + ".tmp"
+                with open(tmp, "w", encoding="utf-8") as f:
+                    f.write(text)
+                os.replace(tmp, sentinel_path)
+
+            def unzip_hf_zip(pth):
+                import zipfile
+
+                base_dir = pth
+                zip_files = [
+                    os.path.join(base_dir, f) for f in os.listdir(base_dir)
+                    if f.endswith('.zip')
+                ]
+                zip_files.sort()
+
+                for zip_file in tqdm(zip_files, desc='Unpacking Origin Data...'):
+                    with zipfile.ZipFile(zip_file, 'r') as zf:
+                        for info in zf.infolist():
+                            if info.is_dir():
+                                continue
+
+                            rel = os.path.normpath(info.filename).lstrip('/\\')
+                            dst = os.path.join(pth, rel)
+
+                            absp = os.path.abspath(pth)
+                            absd = os.path.abspath(dst)
+                            if not absd.startswith(absp + os.sep):
+                                raise RuntimeError(f'Unsafe path in zip: {info.filename}')
+
+                            os.makedirs(os.path.dirname(dst), exist_ok=True)
+                            with zf.open(info, 'r') as src, open(dst, 'wb') as out:
+                                out.write(src.read())
+
+                sentinel_path = os.path.join(pth, SENTINEL_NAME)
+                _write_sentinel(sentinel_path, text="done")
+                print('ViewSpatial data extracted to current directory with original layout.')
+
+            if modelscope_flag_set():
+                from modelscope import dataset_snapshot_download
+                dataset_path = dataset_snapshot_download(dataset_id=repo_id)
+            else:
+                dataset_path = snapshot_download(repo_id=repo_id, repo_type='dataset')
+
+            unzip_hf_zip(dataset_path)
+
+        # === Transfer rel path to abs path ===
+        if 'image_path' in data.columns:
+            def fix_one(x: str):
+                if not isinstance(x, str):
+                    return x
+                s = x.strip()
+                s = os.path.expanduser(os.path.expandvars(s))
+
+                if not dataset_path:
+                    return os.path.normpath(s)
+                return os.path.normpath(os.path.join(dataset_path, s.lstrip(r'\/')))
+
+            def to_abs(p):
+                if isinstance(p, list):
+                    return [fix_one(xx) for xx in p]
+                if isinstance(p, str) and p.strip().startswith('[') and p.strip().endswith(']'):
+                    try:
+                        lst = ast.literal_eval(p)
+                        if isinstance(lst, list):
+                            return [fix_one(xx) for xx in lst]
+                    except Exception:
+                        pass
+                return fix_one(p)
+
+            data['image_path'] = data['image_path'].map(to_abs)
+
+        return data
+
+    def build_prompt(self, line):
+        if self.meta_only:
+            tgt_path = toliststr(line['image_path'])
+        else:
+            tgt_path = self.dump_image(line)
+
+        question = line['question']
+        choices = line['candidates']
+
+        # prompt format from viewspatial bench paper
+        question_text = f"Question: {question}\n"
+        choices_text = f"Choices: {choices}\n"
+        post_prompt = "Reply only to the corresponding option.\nAnswer:"
+
+        prompt = question_text + choices_text + post_prompt
+
+        msgs = []
+        if isinstance(tgt_path, list):
+            msgs.extend([dict(type='image', value=p) for p in tgt_path])
+        else:
+            msgs = [dict(type='image', value=tgt_path)]
+        msgs.append(dict(type='text', value=prompt))
+
+        return msgs
+
+    def evaluate(self, eval_file, **judge_kwargs):
+        from .utils.spatial_bench.cal_scores import eval_mcq_score, build_mcq_score_fn
+
+        # Select MCQ scoring function (rule-based or LLM-based) according to judge_kwargs['model'].
+        score_fn = build_mcq_score_fn(**judge_kwargs)
+
+        return eval_mcq_score(
+            load_fn=load,
+            eval_file=eval_file,
+            score_fn=score_fn,
+            group_col='question_type',
+            order=self._task_category(),
+            dataset_name=getattr(self, 'dataset_name', 'ViewSpatialBench')
+        )


### PR DESCRIPTION
Hi, I added some new benchmarks into this repo. Please feel free to comment if there's any problem.


### Benchmark Table

| No. | Benchmark            | Category   | Importance | 当前实现进度 | 原始仓库支持情况 | 官方VLMEvalKit实现 | 仓库对应名称/说明 | 官方实现/代码 |
|-----|----------------------|------------|------------|--------------|------------------|--------------------|-------------------|---------------|
| 1   | MathCanvas-in (3k)   | Math       | 0          | ✓ | 暂不支持（仅 `MathCanvas-Bench`） | 暂不支持（仅 `MathCanvas-Bench`） | 当前仓库新增兼容名称 `MathCanvas-in`、`MathCanvas-in (3k)`，实际映射到官方公开的 `MathCanvas-Bench` 3K benchmark | [MathCanvas](https://github.com/shiwk24/MathCanvas) |
| 2   | MathVision           | Math       | 0          | ✓ | 支持 | 支持 | `MathVision`、`MathVision_MINI` | [MATH-V / MathVision](https://github.com/mathllm/MATH-V) |
| 3   | MathVista            | Math       | 0          | ✓ | 暂不支持（仅 `MathVista_MINI`） | 暂不支持（仅 `MathVista_MINI`） | 当前仓库新增完整 `MathVista` 本地官方数据接入，同时保留 `MathVista_MINI` | [MathVista](https://github.com/lupantech/MathVista) |
| 4   | VSP / VSP-in         | Spatial    | 0          |  | 暂不支持（仅 `VSP_maze_task_main_original`） | 暂不支持 | 当前仓库新增 `VSP`、`VSP-in` 命名兼容，但底层仍对应官方已公开的 `VSP_maze_task_main_original` maze split；官方仓库暂未公开完整 benchmark 数据 | [VisualPlanning](https://github.com/yix8/VisualPlanning) |
| 5   | MindCube             | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库新增 `MindCube`、`MindCubeBench`、`MindCubeBench_raw_qa`、`MindCubeBench_tiny_raw_qa` | [MindCube](https://github.com/mll-lab-nu/MindCube) |
| 6   | MMSI                 | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库新增 `MMSI`、`MMSIBench`、`MMSIBench_wo_circular`；`MMSI` 默认映射官方 non-circular 评测集 | [MMSI-Bench](https://github.com/OpenRobotLab/MMSI-Bench) |
| 7   | EMMA                 | General    | 0          | ✓ | 支持 | 支持 | `EMMA`、`EMMA_COT` | [EMMA](https://github.com/EMMA-Bench/EMMA) |
| 8   | V*StarBench          | Perception | 0          | ✓ | 支持 | 支持 | `VStarBench` | [V* / VStarBench](https://github.com/penghao-wu/vstar) |
| 9   | HRBench              | Perception | 0          | ✓ | 支持 | 支持 | `HRBench4K`、`HRBench8K` | [HR-Bench](https://github.com/DreamMr/HR-Bench) |
| 10  | CVBench              | Perception | 0          | ✓ | 支持 | 支持 | `CV-Bench-2D`、`CV-Bench-3D` | [Cambrian / CV-Bench](https://github.com/cambrian-mllm/cambrian) |
| 11  | MMVP                 | Perception | 0          | ✓ | 支持 | 支持 | `MMVP` | [MMVP](https://github.com/tsb0601/MMVP) |
| 12  | BLINK                | Perception | 0          | ✓ | 支持 | 支持 | `BLINK`、`BLINK_circular`，另含 `BLINK_Jigsaw` | [BLINK](https://github.com/zeyofu/BLINK_Benchmark) |
| 13  | MMMU                 | General    | 0          | ✓ | 支持 | 支持 | `MMMU_DEV_VAL`、`MMMU_TEST`，另含 `MMMU_Pro_*` | [MMMU](https://github.com/MMMU-Benchmark/MMMU) |
| 14  | ScienceQA            | General    | 0          | ✓ | 支持 | 支持 | `ScienceQA_VAL`、`ScienceQA_TEST` | [ScienceQA](https://github.com/lupantech/ScienceQA) |
| 15  | ARC-AGI              | General    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增 `ARC-AGI`：基于官方 `ARC-AGI-2` public evaluation JSON 渲染任务图，要求模型输出 JSON grid，并做 exact-match task-level eval | [ARC-AGI-2](https://github.com/arcprize/ARC-AGI-2) |
| 16  | MathVerse            | Math       | 0          | ✓ | 暂不支持（仅 `MathVerse_MINI` 系列） | 暂不支持（仅 `MathVerse_MINI` 系列） | 当前仓库新增 `MathVerse` 官方 public 数据接入，实际基于官方 HF 公开的 `testmini`（3940 samples）构建；仍不等同于未公开的完整全量集 | [MathVerse](https://github.com/ZrrSkywalker/MathVerse) |
| 17  | OmniSpatial          | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，新增别名 `OmniSpatial`，默认映射到 `OmniSpatialBench`；同时支持 `OmniSpatialBench_default`、`OmniSpatialBench_zeroshot_cot`、`OmniSpatialBench_manual_cot` | [OmniSpatial](https://github.com/qizekun/OmniSpatial) |
| 18  | Super-CLEVR          | Spatial    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增官方 HF 数据接入，基于 `images.zip + superCLEVR_questions_30k.json` 构建 `Super-CLEVR` 数据集并做短答 exact-match eval | [Super-CLEVR](https://github.com/Lizw14/Super-CLEVR) |
| 19  | SITE                 | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，新增别名 `SITE`、`SITE-Image`，默认映射到 `SiteBenchImage`；同时支持 `SiteBenchVideo_32frame`、`SiteBenchVideo_64frame`、`SiteBenchVideo_1fps`，其中 video 评测依赖 `decord` | [SITE-Bench](https://github.com/wenqi-wang20/SITE-Bench) |
| 20  | SpatialViz-Bench     | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，新增别名 `SpatialViz-Bench`，默认映射到 `SpatialVizBench`；同时支持 `SpatialVizBench_CoT` | [SpatialViz-Bench](https://github.com/wangst0181/SpatialViz-Bench) |
| 21  | ViewSpatial-Bench    | Spatial    | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，新增别名 `ViewSpatial-Bench`，默认映射到 `ViewSpatialBench` | [ViewSpatial-Bench](https://github.com/ZJU-REAL/ViewSpatial-Bench) |
| 22  | 3DSRBench            | Spatial    | 0          | ✓ | 支持 | 支持 | `3DSRBench`；官方公开可获取形式主要是 HuggingFace dataset repo，当前已按该源 clone | [3DSRBench](https://huggingface.co/datasets/ccvl/3DSRBench) |
| 23  | All-Angles Bench     | Spatial    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增 `All_Angles_Bench`，并兼容别名 `All-Angles Bench` / `All-Angles-Bench`；数据按官方 HF `data.json` 自动转成 TSV，多图 MCQ eval 复用框架通用流程 | [All-Angles Bench](https://github.com/Chenyu-Wang567/All-Angles-Bench) |
| 24  | ERQA                 | Embodied   | 0          | ✓ | 暂不支持 | 支持 | 当前仓库已同步接入，支持 `ERQA` / `ERQABench` 评测流程 | [ERQA](https://github.com/embodiedreasoning/ERQA) |
| 25  | Embodied-bench       | Embodied   | 0          |  | 暂不支持（仅 `StaticEmbodiedBench`） | 暂不支持（仅 `StaticEmbodiedBench`） | 当前仓库与官方 VLMEvalKit 仅内置 `StaticEmbodiedBench`、`StaticEmbodiedBench_circular`，不等同于完整 `EmbodiedBench` agent benchmark | [EmbodiedBench](https://github.com/EmbodiedBench/EmbodiedBench) |
| 26  | SEED-Bench-2-Plus    | Perception | 0          | ✓ | 支持 | 支持 | `SEEDBench2_Plus` | [SEED-Bench](https://github.com/AILab-CVC/SEED-Bench) |
| 27  | MME-RealWorld-Lite   | Perception | 0          | ✓ | 支持 | 支持 | `MME-RealWorld-Lite`，另含 `MME-RealWorld`、`MME-RealWorld-CN` | [MME-RealWorld](https://github.com/MME-Benchmarks/MME-RealWorld) |
| 28  | RealWorldQA          | Perception | 0          | ✓ | 支持 | 支持 | `RealWorldQA` | [RealWorldQA](https://huggingface.co/datasets/xai-org/RealworldQA) |
| 29  | MMStar               | General    | 0          | ✓ | 支持 | 支持 | `MMStar`，另含 `MMStar_KO`、`MMStar_TR`、`MMStar_MINI` | [MMStar](https://github.com/MMStar-Benchmark/MMStar) |
| 30  | TRI-Bench            | General    | 0          | ✓ | 暂不支持 | 暂不支持 | 当前仓库新增 `TRI-Bench`：复用官方 prompt 与官方 `3D/2D` 评分公式，对每张图输出六个 JSON 字段，并汇总 `overall_3d_accuracy / overall_2d_accuracy` | [TRI-Bench](https://github.com/Amiton7/Tri-Bench) |
| 31  | OrderBench           | General    | 0          |  | 暂不支持 | 暂不支持 | 当前仓库与官方 VLMEvalKit 均暂未发现内置实现；暂未检索到可靠公开官方代码 | 暂未找到可靠公开官方代码 |